### PR TITLE
Allow optional rules to be bundled and included by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,17 +193,25 @@ Or using the Gradle plugin portal:
     }
 ```
 
-
 Once configured, run the following:
 
     $ ./gradlew packageRules
-    
 
 ## Customizing rule file locations
 
 ```groovy
     checkResolutionRulesSyntax {
         rules files('./alternative-rules.json', './src/rules/moreRules.json')
+    }
+```
+
+## Optional rules
+
+By default, all json files within the rules artifact are applied, however prefixing the filename with `optional-` makes the rule an optional. A rule file called `optional-slf4j.json` can be included using:
+
+```groovy
+    nebulaResolutionRules {
+        include = ['slf4j']
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,31 @@ Dependency rules are read from the `resolutionRules` configuration. Zip and jar 
         resolutionRules 'com.myorg:resolution-rules:latest.release'
     }
 ```
-    
+
+## Excluding rules
+
+Rules may be excluded by filename, omitting the `.json` extension:
+
+```groovy
+    nebulaResolutionRules {
+        exclude = ['local-rules']
+    }
+```
+
+## Including optional rules
+
+Optional rules files are prefixed with `optional-`, and must be included explicitly, omitting the `.json` extension from the filename:
+
+```groovy
+    dependencies {
+        resolutionRules files('optional-local-rules.json')
+    }
+
+    nebulaResolutionRules {
+        include = ['optional-local-rules']
+    }
+```
+
 # Producing rules
 
 The `nebula.resolution-rules-producer` plugin is provided to facilitate creation of rule files. This plugin can be used to validate and package rule files. To use, put your rules file in `src/resolutionRules/resolution-rules.json` and execute the packageRules task. If successful, a jar with the validated rules file will be placed in your build directory. For specifying more than one source file, see documentation below.
@@ -205,15 +229,7 @@ Once configured, run the following:
     }
 ```
 
-## Optional rules
-
-By default, all json files within the rules artifact are applied, however prefixing the filename with `optional-` makes the rule an optional. A rule file called `optional-slf4j.json` can be included using:
-
-```groovy
-    nebulaResolutionRules {
-        include = ['slf4j']
-    }
-```
+Prefix the rule filename with `optional-` to make a rules filename optional, and prevent it from being applied by default.
 
 # Example rules JSON
 

--- a/src/functionalTest/groovy/nebula/plugin/resolutionrules/PluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/nebula/plugin/resolutionrules/PluginFunctionalTest.groovy
@@ -24,10 +24,13 @@ import org.codehaus.groovy.runtime.StackTraceUtils
  * Functional test for {@link ResolutionRulesPlugin}.
  */
 class PluginFunctionalTest extends IntegrationSpec {
-    def rulesJsonFile
+    File rulesJsonFile
+    File optionalRulesJsonFile
 
     def setup() {
         rulesJsonFile = new File(projectDir, "${moduleName}.json")
+        optionalRulesJsonFile = new File(projectDir, "optional-${moduleName}.json")
+
         buildFile << """
                      apply plugin: 'java'
                      apply plugin: 'nebula.resolution-rules'
@@ -37,7 +40,7 @@ class PluginFunctionalTest extends IntegrationSpec {
                      }
 
                      dependencies {
-                         resolutionRules files("$rulesJsonFile")
+                         resolutionRules files("$rulesJsonFile", "$optionalRulesJsonFile")
                      }
                      """.stripIndent()
 
@@ -86,6 +89,28 @@ class PluginFunctionalTest extends IntegrationSpec {
                             "align": []
                         }
                         """.stripIndent()
+
+        optionalRulesJsonFile << """
+                                    {
+                                        "substitute" : [
+                                            {
+                                                "module" : "log4j:log4j",
+                                                "with" : "org.slf4j:log4j-over-slf4j:1.7.21",
+                                                "reason" : "SLF4J bridge replacement",
+                                                "author" : "Danny Thomas <dmthomas@gmail.com>",
+                                                "date" : "2015-10-07T20:21:20.368Z"
+                                            }
+                                        ],
+                                        "align": [
+                                            {
+                                                "group": "org.slf4j",
+                                                "reason": "Align SLF4J dependencies",
+                                                "author" : "Danny Thomas <dmthomas@gmail.com>",
+                                                "date" : "2015-10-07T20:21:20.368Z"
+                                            }
+                                        ]
+                                    }
+                                 """
     }
 
     def 'plugin applies'() {
@@ -198,12 +223,55 @@ class PluginFunctionalTest extends IntegrationSpec {
         result.standardOutput.contains('bouncycastle:bcprov-jdk15:140 -> org.bouncycastle:bcprov-jdk15:latest.release')
     }
 
+    def 'optional rules are not applied by default'() {
+        given:
+        buildFile << """
+                     dependencies {
+                         compile 'log4j:log4j:1.2.17'
+                     }
+                     """.stripIndent()
+
+
+        when:
+        def result = runTasksSuccessfully('dependencies', '--configuration', 'compile')
+
+        then:
+        result.standardOutput.contains('\\--- log4j:log4j:1.2.17\n')
+    }
+
+    def 'optional rules are applied when included'() {
+        given:
+        buildFile << """
+                     nebulaResolutionRules {
+                         include = ["${moduleName}"]
+                     }
+
+                     dependencies {
+                         resolutionRules files("$optionalRulesJsonFile")
+
+                         compile 'log4j:log4j:1.2.17'
+                         compile 'org.slf4j:jcl-over-slf4j:1.7.0'
+                     }
+                     """.stripIndent()
+
+
+        when:
+        def result = runTasksSuccessfully('dependencies', '--configuration', 'compile')
+
+        then:
+        result.standardOutput.contains("""\
++--- log4j:log4j:1.2.17 -> org.slf4j:log4j-over-slf4j:1.7.21
+|    \\--- org.slf4j:slf4j-api:1.7.21
+\\--- org.slf4j:jcl-over-slf4j:1.7.0 -> 1.7.21
+     \\--- org.slf4j:slf4j-api:1.7.21
+""")
+    }
+
     def 'missing version in substitution rule'() {
         given:
         rulesJsonFile.delete()
         rulesJsonFile << """
                          {
-                             "replace" : [],
                              "substitute": [
                                  {
                                      "module" : "asm:asm",
@@ -212,10 +280,7 @@ class PluginFunctionalTest extends IntegrationSpec {
                                      "author" : "Danny Thomas <dmthomas@gmail.com>",
                                      "date" : "2015-10-07T20:21:20.368Z"
                                  }
-                             ],
-                             "reject": [],
-                             "deny": [],
-                             "align": []
+                             ]
                          }
                          """.stripIndent()
         when:

--- a/src/functionalTest/groovy/nebula/plugin/resolutionrules/PluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/nebula/plugin/resolutionrules/PluginFunctionalTest.groovy
@@ -243,7 +243,7 @@ class PluginFunctionalTest extends IntegrationSpec {
         given:
         buildFile << """
                      nebulaResolutionRules {
-                         include = ["${moduleName}"]
+                         include = ["optional-${moduleName}"]
                      }
 
                      dependencies {

--- a/src/functionalTest/groovy/nebula/plugin/resolutionrules/PluginValidationTest.groovy
+++ b/src/functionalTest/groovy/nebula/plugin/resolutionrules/PluginValidationTest.groovy
@@ -141,19 +141,6 @@ class PluginValidationTest extends IntegrationSpec {
         }
     }
 
-    def 'check that it fails when types are missing'() {
-        rulesJson.remove('replace')
-
-        rulesJsonFile.text = JsonOutput.toJson(rulesJson)
-
-        when:
-        def result = runTasks('checkResolutionRulesSyntax')
-
-        then:
-        def rootCause = extractRootCause(result.failure)
-        rootCause.message.contains('There must be exactly 5 resolution rule types defined')
-    }
-
     def 'check that validation task mandates lists for types'() {
         rulesJson.replace = 'What is a string doing here instead of a List?'
 

--- a/src/main/groovy/nebula/plugin/resolutionrules/NebulaResolutionRulesExtension.groovy
+++ b/src/main/groovy/nebula/plugin/resolutionrules/NebulaResolutionRulesExtension.groovy
@@ -17,5 +17,7 @@
 package nebula.plugin.resolutionrules
 
 class NebulaResolutionRulesExtension {
+    List<String> include = []
+    List<String> exclude = []
     Collection<String> skipAlignRules = []
 }

--- a/src/main/groovy/nebula/plugin/resolutionrules/ResolutionJsonValidator.groovy
+++ b/src/main/groovy/nebula/plugin/resolutionrules/ResolutionJsonValidator.groovy
@@ -47,11 +47,6 @@ class ResolutionJsonValidator {
     }
 
     static def validateJson(Object json) {
-        // ensure there are exactly 5 types
-        if (json.size() != 5) {
-            throw new InvalidRulesJsonException('There must be exactly 5 resolution rule types defined')
-        }
-
         // ensure all types are lists
         if (json.any { it.value.getClass() != ArrayList }) {
             throw new InvalidRulesJsonException('All resolution rule types must be lists')

--- a/src/main/groovy/nebula/plugin/resolutionrules/ResolutionRulesPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/resolutionrules/ResolutionRulesPlugin.groovy
@@ -91,7 +91,7 @@ class ResolutionRulesPlugin implements Plugin<Project> {
                     jar.close()
                 }
             } else {
-                logger.error("Unsupported rules file extension for $file")
+                logger.debug("Unsupported rules file extension for $file")
             }
         }
         return flattenRules(rules)

--- a/src/main/groovy/nebula/plugin/resolutionrules/ResolutionRulesPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/resolutionrules/ResolutionRulesPlugin.groovy
@@ -101,7 +101,7 @@ class ResolutionRulesPlugin implements Plugin<Project> {
         if (filename.endsWith(".json")) {
             String nameWithoutExtension = filename.replace(".json", "")
             if (nameWithoutExtension.startsWith("optional-")) {
-                return extension.include.contains(nameWithoutExtension.replaceFirst("optional-", ""))
+                return extension.include.contains(nameWithoutExtension)
             } else {
                 return !extension.exclude.contains(nameWithoutExtension)
             }

--- a/src/main/groovy/nebula/plugin/resolutionrules/Rules.groovy
+++ b/src/main/groovy/nebula/plugin/resolutionrules/Rules.groovy
@@ -15,8 +15,6 @@
  */
 package nebula.plugin.resolutionrules
 
-import nebula.plugin.resolutionrules.ModuleIdentifier
-import nebula.plugin.resolutionrules.ModuleVersionIdentifier
 import org.gradle.api.Project
 import org.gradle.api.artifacts.*
 import org.gradle.api.artifacts.component.ComponentSelector


### PR DESCRIPTION
I want https://github.com/nebula-plugins/gradle-resolution-rules to provide a single artifact, but some rules are opinionated so need to be opt-in. This provides both includes and excludes based on rules filenames, with files named `optional-` excluded unless explicitly included.