### PR TITLE
Multipass-alignment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,14 @@
 plugins {
     id 'com.gradle.plugin-publish' version '0.9.5'
     id 'nebula.plugin-plugin' version '5.0.0'
-    id 'nebula.kotlin' version '1.0.3'
+    id 'nebula.kotlin' version '1.0.6'
 }
 
 apply plugin: 'kotlin'
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-reflect:1.0.3'
-    compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.7.4'
+    compile 'org.jetbrains.kotlin:kotlin-reflect:1.0.6'
+    compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.7.5'
 }
 
 facets {

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -207,7 +207,7 @@ data class AlignRules(val aligns: List<AlignRule>) : Rule {
                 .partition { it is ResolvedDependencyResult }
         if (shouldLog && unresolved.isNotEmpty()) {
             logger.warn("Resolution rules could not resolve all dependencies to align in configuration '${sourceConfiguration.name}' should also fail to resolve (use --info to list unresolved dependencies)")
-            logger.info("Resolution rules could not resolve:\n ${unresolved.map { "- $it" }.joinToString("\n")}")
+            logger.info("Resolution rules could not resolve:\n ${unresolved.map { " - $it" }.joinToString("\n")}")
         }
         val moduleVersions = resolved
                 .map { it as ResolvedDependencyResult }


### PR DESCRIPTION
This performs multiple passes on alignment, ensuring that requested versions for aligned transitive dependencies are reflected.

![Multipass!](http://i.imgur.com/SvFyNBK.jpg)

This hasn't resulted in any increase in our test times, so that bodes well for the performance impact, but we'll definitely want to test this against our more pathological projects internally.