### PR TITLE
Fail build when substitute and force conflict

### DIFF
--- a/src/main/kotlin/nebula/plugin/resolutionrules/configurations.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/configurations.kt
@@ -4,6 +4,9 @@ import com.netflix.nebula.dependencybase.DependencyManagement
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ExternalDependency
+import org.gradle.api.artifacts.ModuleVersionSelector
+import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.util.Path
 import java.lang.reflect.Field
@@ -89,3 +92,11 @@ tailrec fun <T> Class<T>.findDeclaredField(name: String): Field {
     throw IllegalArgumentException("Could not find field $name")
 }
 
+object ConfigurationService {
+    fun forces(configuration: Configuration): Set<ModuleVersionSelector> {
+        val resolutionStrategyForces = configuration.resolutionStrategy.forcedModules
+        val inlineForces = configuration.dependencies.filter { it is ExternalDependency && it.isForce }
+                .map { DefaultModuleVersionSelector(it.group, it.name, it.version) }
+        return resolutionStrategyForces + inlineForces
+    }
+}


### PR DESCRIPTION
If a build is trying to force to a version that is substituted away from, fail the build. This behavior generally wouldn't be intentional, and could be avoided by either forcing a different version, or excluding the rule.