### PR TITLE
Don't align scala incremental analysis configurations

### DIFF
--- a/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
@@ -44,12 +44,13 @@ class ResolutionRulesPlugin : Plugin<Project> {
     private lateinit var extension: NebulaResolutionRulesExtension
     private lateinit var mapper: ObjectMapper
     private var reasons: MutableSet<String> = mutableSetOf()
-    private val ignoredConfigurations = listOf(RESOLUTION_RULES_CONFIG_NAME, SPRING_VERSION_MANAGEMENT_CONFIG_NAME,
-            NEBULA_RECOMMENDER_BOM_CONFIG_NAME)
+    private val ignoredConfigurationPrefixes = listOf(RESOLUTION_RULES_CONFIG_NAME, SPRING_VERSION_MANAGEMENT_CONFIG_NAME,
+            NEBULA_RECOMMENDER_BOM_CONFIG_NAME, SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX)
 
     companion object Constants {
         fun isCoreAlignmentEnabled() = java.lang.Boolean.getBoolean("nebula.features.coreAlignmentSupport")
         const val SPRING_VERSION_MANAGEMENT_CONFIG_NAME = "versionManagement"
+        const val SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX = "incrementalScalaAnalysis"
         const val JSON_EXT = ".json"
         const val JAR_EXT = ".jar"
         const val ZIP_EXT = ".zip"
@@ -73,7 +74,7 @@ class ResolutionRulesPlugin : Plugin<Project> {
         }
 
         project.configurations.all { config ->
-            if (ignoredConfigurations.contains(config.name)) {
+            if (ignoredConfigurationPrefixes.any { config.name.startsWith(it) }) {
                 return@all
             }
 


### PR DESCRIPTION
They are created for each source set so we need to exclude all of them based on prefix.