### PR TITLE
Substitute and align interaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile 'org.jetbrains.kotlin:kotlin-reflect'
     compile 'com.netflix.nebula:nebula-gradle-interop:latest.release'
     compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2'
+    compile 'com.netflix.nebula:nebula-dependency-recommender:7.5.6'
 
     testImplementation gradleTestKit()
     testRuntime 'com.netflix.nebula:gradle-dependency-lock-plugin:7.+'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -4,13 +4,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
-            "requested": "1.3.11"
+            "locked": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.3.11",
@@ -22,12 +25,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -40,12 +47,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -58,12 +69,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -76,12 +91,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -94,16 +113,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -116,16 +139,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -138,16 +165,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -160,16 +191,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -183,19 +218,23 @@
             "requested": "2.9.2"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "7.1.0",
+            "locked": "7.3.4",
             "requested": "7.+"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -209,19 +248,23 @@
             "requested": "2.9.2"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "7.1.0",
+            "locked": "7.3.4",
             "requested": "7.+"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -231,12 +274,12 @@
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.2"
+            "locked": "0.8.3"
         }
     },
     "jacocoAnt": {
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.2"
+            "locked": "0.8.3"
         }
     },
     "kotlinCompilerClasspath": {
@@ -255,12 +298,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -273,12 +320,16 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -291,16 +342,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -313,16 +368,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -335,16 +394,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -357,16 +420,20 @@
             "locked": "2.9.2",
             "requested": "2.9.2"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -380,19 +447,23 @@
             "requested": "2.9.2"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "7.1.0",
+            "locked": "7.3.4",
             "requested": "7.+"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
@@ -406,19 +477,23 @@
             "requested": "2.9.2"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "7.1.0",
+            "locked": "7.3.4",
             "requested": "7.+"
         },
+        "com.netflix.nebula:nebula-dependency-recommender": {
+            "locked": "7.5.6",
+            "requested": "7.5.6"
+        },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.2.4",
             "requested": "7.+"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.1.3",
+            "locked": "1.3.11",
             "requested": "1.3.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
@@ -1,0 +1,1383 @@
+package nebula.plugin.resolutionrules
+
+
+import nebula.test.IntegrationTestKitSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.ModuleBuilder
+import nebula.test.dependencies.maven.ArtifactType
+import nebula.test.dependencies.maven.Pom
+import nebula.test.dependencies.repositories.MavenRepo
+import spock.lang.Unroll
+
+class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
+    File rulesJsonFile
+    File mavenrepo
+    String reason = "★ custom reason"
+
+    String alignRuleForTestNebula = """\
+        {
+            "group": "(test.nebula|test.nebula.ext)",
+            "reason": "Align test.nebula dependencies",
+            "author": "Example Person <person@example.org>",
+            "date": "2016-03-17T20:21:20.368Z"
+        }""".stripIndent()
+
+    def setup() {
+        rulesJsonFile = new File(projectDir, "rules.json")
+
+        settingsFile << """\
+            rootProject.name = 'test-project'
+            """.stripIndent()
+
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:a:0.5.0')
+
+                .addModule('test.nebula:a:1.0.0')
+                .addModule('test.nebula:a:1.0.1')
+                .addModule('test.nebula:a:1.0.2')
+                .addModule('test.nebula:a:1.0.3')
+                .addModule('test.nebula:a:1.1.0')
+
+                .addModule('test.nebula:b:0.5.0')
+
+                .addModule('test.nebula:b:1.0.0')
+                .addModule('test.nebula:b:1.0.1')
+                .addModule('test.nebula:b:1.0.2')
+                .addModule('test.nebula:b:1.0.3')
+                .addModule('test.nebula:b:1.1.0')
+
+                .addModule('test.nebula:c:1.0.0')
+                .addModule('test.nebula:c:1.0.1')
+                .addModule('test.nebula:c:1.0.2')
+                .addModule('test.nebula:c:1.0.3')
+                .addModule('test.nebula:c:1.1.0')
+
+                .addModule('test.nebula:c:1.4.0')
+
+                .addModule('test.beverage:d:1.0.0')
+                .addModule(new ModuleBuilder('test.other:e:1.0.0').addDependency('test.nebula:b:1.1.0').build())
+                .build()
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'nebula.resolution-rules'
+            }
+            repositories {
+                maven { url '${projectDir.toPath().relativize(mavenrepo.toPath()).toFile()}' }
+            }
+            dependencies {
+                resolutionRules files("${projectDir.toPath().relativize(rulesJsonFile.toPath()).toFile()}")
+            }
+            """.stripIndent()
+
+        debug = true
+        keepFiles = true
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from static version to higher static version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.1"               | "1.0.3"             | "higher"           | false         | "1.0.3"
+        "static version"      | "1.0.1"               | "1.0.3"             | "higher"           | true          | "1.0.3"
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from static version to higher latest.release dynamic version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.1"               | "latest.release"    | "higher"           | false         | "1.1.0"
+        "static version"      | "1.0.1"               | "latest.release"    | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from static version to higher minor-scoped dynamic version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.1"               | "1.+"               | "higher"           | false         | "1.1.0"
+        "static version"      | "1.0.1"               | "1.+"               | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'statically defined dependency: core alignment should substitute and align from static version to lower substitute-to version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.1"               | "1.0.0"             | "lower"            | false         | "1.0.1"
+        "static version"      | "1.0.1"               | "1.0.0"             | "lower"            | true          | "1.0.0"
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from range to higher static version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "[1.0.1,1.0.2]"       | "1.0.3"             | "higher"           | false         | "1.0.3"
+        "range"               | "[1.0.1,1.0.2]"       | "1.0.3"             | "higher"           | true          | "1.0.3"
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from range to higher latest.release dynamic version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "[1.0.1,1.0.2]"       | "latest.release"    | "higher"           | false         | "1.1.0"
+        "range"               | "[1.0.1,1.0.2]"       | "latest.release"    | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from range to higher major-scoped dynamic version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "[1.0.1,1.0.2]"       | "1.+"               | "higher"           | false         | "1.1.0"
+        "range"               | "[1.0.1,1.0.2]"       | "1.+"               | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'statically defined dependency: alignment styles should substitute and align from range to higher static version with higher minor version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "[1.0.1,1.0.2]"       | "1.1.0"             | "higher"           | false         | "1.1.0"
+        "range"               | "[1.0.1,1.0.2]"       | "1.1.0"             | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'statically defined dependency: core alignment should substitute and align from range to lower substitute-to version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.1"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "[1.0.1,1.0.2]"       | "1.0.0"             | "lower"            | false         | "1.0.1"
+        "range"               | "[1.0.1,1.0.2]"       | "1.0.0"             | "lower"            | true          | "1.0.0"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher static version that is not substituted-away-from | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | false         | "1.0.3"
+        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | true          | "1.0.2"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher latest.release dynamic version in narrow definition that is not substituted-away-from | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | false         | "1.0.3"
+        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | true          | "1.0.2"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher major-scoped dynamic version that is not substituted-away-from | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.3"               | "1.+"               | "higher"           | false         | "1.0.3"
+        "static version"      | "1.0.3"               | "1.+"               | "higher"           | true          | "1.0.2"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to conflict-resolved version that is is not substituted-away-from | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | false         | "1.0.3"
+        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | true          | "1.0.2"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher static version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "(,1.1.0)"            | "1.1.0"             | "higher"           | false         | "1.1.0"
+        "range"               | "(,1.1.0)"            | "1.1.0"             | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher latest.release dynamic version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "(,1.1.0)"            | "latest.release"    | "higher"           | false         | "1.1.0"
+        "range"               | "(,1.1.0)"            | "latest.release"    | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher static version with higher minor version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "(,1.1.0)"            | "1.+"               | "higher"           | false         | "1.1.0"
+        "range"               | "(,1.1.0)"            | "1.+"               | "higher"           | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from range to lower substitute-to version | core alignment: #coreAlignment'() {
+        given:
+        def dependencyDefinitionVersion = "1.0.+"
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
+        "range"               | "(,1.1.0)"            | "0.5.0"             | "lower"            | false         | "1.0.3"
+        "range"               | "(,1.1.0)"            | "0.5.0"             | "lower"            | true          | "0.5.0"
+    }
+
+    @Unroll
+    def 'missing cases: statically defined dependency: core alignment fails to align when lower versions are missing | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        // missing cases: statically defined dependency: core alignment fails to align when lower versions are missing | core alignment: #coreAlignment
+        "static version"   | "1.0.1"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | false         | "1.0.1"            | "1.0.1"
+        "static version"   | "1.0.1"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | true          | "0.5.0"            | "FAILED"
+    }
+
+    @Unroll
+    def 'missing cases: statically defined dependency: core alignment fails to align when higher versions are missing | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        "static version"   | "1.0.1"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | false         | "1.1.0"            | "1.4.0"
+        "static version"   | "1.0.1"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"           | "1.4.0"
+    }
+
+    @Unroll
+    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        "range"            | "1.+"          | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | false         | "1.1.0"            | "1.4.0"
+        "range"            | "1.+"          | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | true          | "FAILED"           | "FAILED"
+    }
+
+    @Unroll
+    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion   | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        "range"            | "latest.release" | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | false         | "1.1.0"            | "1.4.0"
+        "range"            | "latest.release" | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | true          | "0.5.0"            | "FAILED"
+    }
+
+    @Unroll
+    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | false         | "1.1.0"            | "1.4.0"
+        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"           | "1.4.0"
+    }
+
+    @Unroll
+    def 'missing cases: narrowly defined dynamic dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        "narrow range"     | "1.0.+"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | false         | "1.0.3"            | "1.0.3"
+        "narrow range"     | "1.0.+"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | true          | "FAILED"           | "FAILED"
+    }
+
+    @Unroll
+    def 'missing cases: narrowly defined dynamic dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
+        given:
+        setupFortSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$ABResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
+        "narrow range"     | "1.0.+"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | false         | "1.0.3"            | "1.0.3"
+        "narrow range"     | "1.0.+"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"           | "FAILED"
+    }
+
+    @Unroll
+    def 'do not apply substitution to group if the specified dependency is not in the graph | core alignment: #coreAlignment'() {
+        given:
+        def module = "test.nebula:$subFromVersionAndModule"
+        def with = "test.nebula:$subToVersionAndModule"
+        createAlignAndSubstituteRule(module, with)
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a:$definedVersion'
+                compile 'test.nebula:b:$definedVersion'
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | resultingVersion
+        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | false         | "1.1.0"
+        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | true          | "1.1.0"
+    }
+
+    @Unroll
+    def 'substitute static version for other dependency latest.release and align direct deps | core alignment #coreAlignment'() {
+        given:
+        def module = "test.beverage:d:1.0.0"
+        def with = "test.nebula:b:latest.release"
+        createAlignAndSubstituteRule(module, with)
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a:1.0.0'
+                compile 'test.beverage:d:1.0.0'
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        def resultingVersion = "1.1.0"
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment << [false, true]
+    }
+
+    @Unroll
+    def 'substitute all versions for another dependency with static version and align direct and transitives higher | core alignment #coreAlignment'() {
+        given:
+        def module = "test.other:e"
+        def with = "test.nebula:b:1.1.0"
+        createAlignAndSubstituteRule(module, with)
+
+        buildFile << """
+            dependencies {
+                compile 'test.other:e:1.0.0'
+                compile 'test.nebula:a:1.0.0'
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        result.output.contains('test.other:e:1.0.0 -> test.nebula:b:1.1.0')
+        result.output.contains('test.nebula:a:1.0.0 -> 1.1.0')
+
+        def resultingVersion = "1.1.0"
+        dependencyInsightContains(result.output, "test.other:e:1.0.0 -> test.nebula:b", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment << [false, true]
+    }
+
+    @Unroll
+    def 'substitute all versions for another dependency with static version and align direct and transitives lower | core alignment #coreAlignment'() {
+        given:
+        def module = "test.other:e"
+        def with = "test.nebula:b:1.0.3"
+        createAlignAndSubstituteRule(module, with)
+
+        buildFile << """
+            dependencies {
+                compile 'test.other:e:1.0.0'
+                compile 'test.nebula:a:1.0.0'
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        def resultingVersion = "1.0.3"
+        dependencyInsightContains(result.output, "test.other:e:1.0.0 -> test.nebula:b", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment << [false, true]
+    }
+
+    @Unroll
+    def 'apply a static version via a force and align results (no substitutions) | core alignment #coreAlignment'() {
+        given:
+        rulesJsonFile << """
+            {
+                "align": [
+                    $alignRuleForTestNebula
+                ]
+            }
+            """.stripIndent()
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a:latest.release'
+                compile 'test.nebula:b:latest.release'
+            }
+            configurations.all {
+                resolutionStrategy {
+                    force 'test.nebula:a:1.0.2'
+                }
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        def resultingVersion = "1.0.2"
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment << [false, true]
+    }
+
+    @Unroll
+    def 'apply a static version via details.useVersion and align results #description | core alignment #coreAlignment'() {
+        // This is not using a substitution rule, so alignment is not totally taking place, as some versions are not rejected
+        // TODO: See about reading in the resolution strategies to catch cases like this
+
+        given:
+        rulesJsonFile << """
+            {
+                "align": [
+                    $alignRuleForTestNebula
+                ]
+            }
+            """.stripIndent()
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a:1.0.3'
+                compile 'test.nebula:b:1.0.0'
+                compile 'test.nebula:c:1.0.3'
+            }
+            configurations.all {
+                resolutionStrategy.eachDependency { details ->
+                    if (details.requested.name == 'a') {
+                        details.useVersion '1.0.1'
+                        details.because('$reason')
+                    }
+                }
+            }
+            """.stripIndent()
+
+        when:
+
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersionForConstrainedVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersionForNonConstrainedVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", resultingVersionForNonConstrainedVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersionForNonConstrainedVersion")
+        }
+
+
+        where:
+        coreAlignment | resultingVersionForConstrainedVersion | resultingVersionForNonConstrainedVersion | description
+        false         | "1.0.3"                               | "1.0.3"                                  | "aligns all dependencies"
+        true          | "1.0.1"                               | "1.0.3"                                  | "does not align all dependencies"
+    }
+
+    @Unroll
+    def 'request a dynamic version and sub all versions higher than x and align | core alignment #coreAlignment'() {
+        given:
+        // based on https://github.com/nebula-plugins/gradle-nebula-integration/issues/50
+        rulesJsonFile << """
+            {
+                "align": [
+                    {
+                        "group": "com.google.inject",
+                        "reason": "Align guice",
+                        "author": "Example Person <person@example.org>",
+                        "date": "2016-03-17T20:21:20.368Z"
+                    }
+                ],
+                "substitute": [
+                    {
+                        "module" : "com.google.inject:guice:[4.2.0,)",
+                        "with" : "com.google.inject:guice:4.1.0",
+                        "reason" : "$reason",
+                        "author" : "Test user <test@example.com>",
+                        "date" : "2015-10-07T20:21:20.368Z"
+                    }
+                ]
+            }
+            """.stripIndent()
+
+        buildFile << """
+repositories {
+    mavenCentral()
+    maven {
+        url 'repo'
+    }
+}
+
+dependencies {
+    //at the time of writing resolves to 4.2.2
+    compile "com.google.inject:guice:4.+"
+    compile "sample:module:1.0"
+}
+"""
+
+        MavenRepo repo = new MavenRepo()
+        repo.root = new File(projectDir, 'repo')
+        Pom pom = new Pom('sample', 'module', '1.0', ArtifactType.POM)
+        pom.addDependency('com.google.inject.extensions', 'guice-grapher', '4.1.0')
+        repo.poms.add(pom)
+        repo.generate()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, false, 'com.google.inject:guice'))
+
+        then:
+        if (coreAlignment) {
+            dependencyInsightContains(result.output, "com.google.inject", resultingVersion)
+        } else {
+            // since this test uses an external dependency that keeps incrementing, let's check that it just doesn't get the same result
+            def content = "com.google.inject:.*4.1.0\n"
+            assert result.output.findAll(content).size() == 0
+
+            // just make sure there's a value here for dependencyInsight
+            dependencyInsightContains(result.output, "com.google.inject", '')
+        }
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | resultingVersion
+        false         | '4.2.2'
+        true          | '4.1.0'
+    }
+
+    @Unroll
+    def 'request a dynamic version and sub version range used in transitive dep and align | core alignment #coreAlignment'() {
+        given:
+        // based on https://github.com/nebula-plugins/gradle-nebula-integration/issues/50
+        rulesJsonFile << """
+            {
+                "align": [
+                    {
+                        "group": "com.google.inject",
+                        "reason": "Align guice",
+                        "author": "Example Person <person@example.org>",
+                        "date": "2016-03-17T20:21:20.368Z"
+                    }
+                ],
+                "substitute": [
+                    {
+                        "module" : "com.google.inject:guice:[4.2.0,)",
+                        "with" : "com.google.inject:guice:4.1.0",
+                        "reason" : "$reason",
+                        "author" : "Test user <test@example.com>",
+                        "date" : "2015-10-07T20:21:20.368Z"
+                    }
+                ]
+            }
+            """.stripIndent()
+
+        buildFile << """
+repositories {
+    mavenCentral()
+    maven {
+        url 'repo'
+    }
+}
+
+dependencies {
+    //at the time of writing, 4.+ resolves to 4.2.1
+    compile "com.google.inject:guice:4.+"
+    compile "sample:module:1.0"
+}
+"""
+
+        MavenRepo repo = new MavenRepo()
+        repo.root = new File(projectDir, 'repo')
+        Pom pom = new Pom('sample', 'module', '1.0', ArtifactType.POM)
+        pom.addDependency('com.google.inject.extensions', 'guice-grapher', '4.2.0')
+        repo.poms.add(pom)
+        repo.generate()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, false, 'com.google.inject:guice'))
+
+        then:
+        def resultingVersion = '4.1.0'
+        if (coreAlignment) {
+            dependencyInsightContains(result.output, "com.google.inject", resultingVersion)
+        } else {
+            // since this test uses an external dependency that keeps incrementing, let's check that it just doesn't get the same result
+            def content = "com.google.inject:.*4.1.0\n"
+            assert result.output.findAll(content).size() == 0
+
+            // just make sure there's a value here for dependencyInsight
+            dependencyInsightContains(result.output, "com.google.inject", '')
+        }
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment << [false, true]
+    }
+
+    @Unroll
+    def 'recs with core bom support disabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false
+        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | false
+    }
+
+    @Unroll
+    def 'recs with core bom support disabled: core alignment should substitute and align from bom version to higher minor-scoped dynamic version | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.+"               | "1.0.2"          | false
+        true          | "1.0.2"    | true                                  | "1.+"               | "1.1.0"          | false
+    }
+
+    @Unroll
+    def 'recs with core bom support disabled: core alignment should substitute and align from bom version to higher patch-scoped dynamic version | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.0.3"             | "1.0.2"          | false
+        true          | "1.0.2"    | true                                  | "1.0.3"             | "1.0.3"          | false
+    }
+
+    @Unroll
+    def 'recs with core bom support disabled: alignment styles should not substitute when resulting version is not in substitute-away-from range | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | false
+        true          | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | false
+    }
+
+    @Unroll
+    def 'recs with core bom support enabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | true
+        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | true
+    }
+
+    @Unroll
+    def 'recs with core bom support enabled: core alignment should substitute and align from bom version to higher minor-scoped dynamic version | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.+"               | "1.0.2"          | true
+        true          | "1.0.2"    | true                                  | "1.+"               | "1.1.0"          | true
+    }
+
+    @Unroll
+    def 'recs with core bom support enabled: core alignment should substitute and align from bom version to higher patch-scoped dynamic version | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.0.3"             | "1.0.2"          | true
+        true          | "1.0.2"    | true                                  | "1.0.3"             | "1.0.3"          | true
+    }
+
+    @Unroll
+    def 'recs with core bom support enabled: alignment styles should not substitute when resulting version is not in substitute-away-from range | core alignment #coreAlignment'() {
+        given:
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
+
+        when:
+        def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | true
+        true          | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | true
+    }
+
+    @Unroll
+    def 'enforced recs with core bom support disabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+        given:
+        def usingEnforcedPlatform = true
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion, usingEnforcedPlatform)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false
+        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | false
+    }
+
+    @Unroll
+    def 'enforced recs with core bom support disabled: alignment styles should not substitute when resulting version is not in substitute-away-from range | core alignment #coreAlignment'() {
+        given:
+        def usingEnforcedPlatform = true
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion, usingEnforcedPlatform)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | false
+        true          | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | false
+    }
+
+    @Unroll
+    def 'enforced recs with core bom support enabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+        given:
+        def usingEnforcedPlatform = true
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion, usingEnforcedPlatform)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | true
+        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | true
+    }
+
+    @Unroll
+    def 'enforced recs with core bom support enabled: alignment styles should not substitute when resulting version is not in substitute-away-from range | core alignment #coreAlignment'() {
+        given:
+        def usingEnforcedPlatform = true
+        setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion, usingEnforcedPlatform)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
+        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
+        false         | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | true
+        true          | "1.0.0"    | false                                 | "1.0.1"             | "1.0.0"          | true
+    }
+
+    private def setupForSimplestSubstitutionAndAlignmentCases(String substituteFromVersion, String substituteToVersion, String dependencyDefinitionVersion) {
+        def module = "test.nebula:b:$substituteFromVersion"
+        def with = "test.nebula:b:$substituteToVersion"
+
+        createAlignAndSubstituteRule(module, with)
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a:$dependencyDefinitionVersion'
+                compile 'test.nebula:b:$dependencyDefinitionVersion'
+            }
+            """.stripIndent()
+    }
+
+    private def setupFortSubstitutionAndAlignmentCasesWithMissingVersions(String subFromVersionAndModule, String subToVersionAndModule, String definedVersion) {
+        def module = "test.nebula:$subFromVersionAndModule"
+        def with = "test.nebula:$subToVersionAndModule"
+        createAlignAndSubstituteRule(module, with)
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a:$definedVersion'
+                compile 'test.nebula:b:$definedVersion'
+                compile 'test.nebula:c:$definedVersion'
+            }
+            """.stripIndent()
+    }
+
+    private def setupForBomAndAlignmentAndSubstitution(String bomVersion, String substituteToVersion, boolean usingEnforcedPlatform = false) {
+        def module = "test.nebula:a:[1.0.2]"
+        def with = "test.nebula:a:$substituteToVersion"
+        createAlignAndSubstituteRule(module, with)
+
+        def bomRepo = createBom(["test.nebula:a:$bomVersion", "test.nebula:b:$bomVersion"])
+
+        def startingBuildFileContents = buildFile.text
+        buildFile.text = ""
+        buildFile << """
+            buildscript {
+                repositories { jcenter() }
+            }
+            plugins {
+                id 'nebula.dependency-recommender' version "7.5.5"
+            }
+            """.stripIndent()
+        buildFile << startingBuildFileContents
+
+
+        if (!usingEnforcedPlatform) {
+            buildFile << """
+            dependencyRecommendations {
+                mavenBom module: 'test.nebula.bom:testbom:latest.release'
+            }
+            """.stripIndent()
+        } else {
+            buildFile << """
+            dependencyRecommendations {
+                mavenBom module: 'test.nebula.bom:testbom:latest.release', enforced: true
+            }
+            """.stripIndent()
+        }
+
+        buildFile << """
+            dependencies {
+                compile 'test.nebula:a'
+                compile 'test.nebula:b'
+            }
+            repositories {
+                 maven { url '${bomRepo.root.absoluteFile.toURI()}' }
+            }
+            """.stripIndent()
+    }
+
+    private def createBom(List<String> dependencies) {
+        MavenRepo repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        Pom pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+
+        dependencies.each { dependency ->
+            def depParts = dependency.split(':')
+            assert depParts.size() == 3
+
+            pom.addManagementDependency(depParts[0], depParts[1], depParts[2])
+        }
+
+        repo.poms.add(pom)
+        repo.generate()
+        return repo
+    }
+
+    private def createAlignAndSubstituteRule(String module, String with) {
+        rulesJsonFile << """
+            {
+                "substitute": [
+                    {
+                        "module" : "$module",
+                        "with" : "$with",
+                        "reason" : "$reason",
+                        "author" : "Test user <test@example.com>",
+                        "date" : "2015-10-07T20:21:20.368Z"
+                    }
+                ],
+                "align": [
+                    $alignRuleForTestNebula
+                ]
+            }
+            """.stripIndent()
+    }
+
+    private static def tasks(Boolean usingCoreAlignment, Boolean usingCoreBomSupport = false, String groupForInsight = 'test.nebula') {
+        return [
+                'dependencyInsight',
+                '--dependency',
+                groupForInsight,
+                "-Dnebula.features.coreAlignmentSupport=$usingCoreAlignment",
+                "-Dnebula.features.coreBomSupport=$usingCoreBomSupport"
+        ]
+    }
+
+    private static void dependencyInsightContains(String resultOutput, String groupAndName, String resultingVersion) {
+        def content = "$groupAndName:.*$resultingVersion\n"
+        assert resultOutput.findAll(content).size() >= 1
+    }
+
+}

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/SubstituteRulesSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/SubstituteRulesSpec.groovy
@@ -3,7 +3,7 @@ package nebula.plugin.resolutionrules
 import nebula.test.IntegrationSpec
 import org.codehaus.groovy.runtime.StackTraceUtils
 
-class SubsituteRulesSpec extends IntegrationSpec {
+class SubstituteRulesSpec extends IntegrationSpec {
     File rulesJsonFile
 
     def setup() {
@@ -80,7 +80,7 @@ class SubsituteRulesSpec extends IntegrationSpec {
         then:
         !result.standardOutput.contains('org.bouncycastle:bcmail-jdk16:1.40')
         result.standardOutput.contains('org.bouncycastle:bcmail-jdk16:')
-        result.standardOutput.contains('substitution because The latest version of BC is required, using the new coordinate')
+        result.standardOutput.contains('The latest version of BC is required, using the new coordinate')
     }
 
     def 'substitute dependency with version'() {

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -18,12 +18,15 @@ package nebula.plugin.resolutionrules
 
 import com.netflix.nebula.interop.VersionWithSelector
 import com.netflix.nebula.interop.action
+import netflix.nebula.dependency.recommender.DependencyRecommendationsPlugin
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.*
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import java.io.Serializable
+import javax.inject.Inject
 import org.gradle.api.artifacts.ModuleVersionIdentifier as GradleModuleVersionIdentifier
 
 interface Rule {
@@ -50,11 +53,14 @@ data class RuleSet(
         val exclude: List<ExcludeRule> = emptyList(),
         val align: List<AlignRule> = emptyList()) {
 
-    fun dependencyRules() =
+    fun dependencyRulesPartOne() =
+            listOf(replace, substitute, reject, deny, exclude).flatten()
+
+    fun dependencyRulesPartTwo() =
             if (ResolutionRulesPlugin.isCoreAlignmentEnabled())
-                listOf(replace, substitute, reject, deny, exclude, align).flatten()
+                listOf(align).flatten()
             else
-                listOf(replace, substitute, reject, deny, exclude).flatten()
+                emptyList()
 
     fun resolveRules() =
             if (ResolutionRulesPlugin.isCoreAlignmentEnabled())
@@ -65,6 +71,103 @@ data class RuleSet(
     fun generateAlignmentBelongsToName() {
         align.forEachIndexed { index, alignRule ->
             alignRule.belongsToName = "$name-$index"
+        }
+    }
+}
+
+class AlignedPlatformRule(alignRule: AlignRule, substituteRules: MutableList<SubstituteRule>) : Serializable {
+    var substituteRules: List<SubstituteRule> = substituteRules
+
+    fun apply(project: Project, configuration: Configuration, resolutionStrategy: ResolutionStrategy, extension: NebulaResolutionRulesExtension, reasons: MutableSet<String>) {
+        substituteRules.forEach {
+            val substitution = resolutionStrategy.dependencySubstitution
+            val selector = substitution.module(it.module)
+            val substitutedModule = selector as? ModuleComponentSelector
+
+            val withModuleId = ModuleVersionIdentifier.valueOf(it.with)
+            if (!withModuleId.hasVersion()) {
+                throw SubstituteRuleMissingVersionException(withModuleId, it, reasons)
+            }
+            val withSelector = substitution.module(withModuleId.toString()) as ModuleComponentSelector
+
+            if (substitutedModule != null && shouldApplyRule(configuration, substitutedModule)) {
+                firstLevelDependenciesRejectTheSubstitutedVersions(project, configuration, substitutedModule, withSelector, resolutionStrategy)
+                transitiveDependenciesRejectTheSubstitutedVersions(project, substitutedModule, withSelector)
+                it.applyForAlignedGroup(project, configuration, configuration.resolutionStrategy, extension, reasons)
+            }
+        }
+    }
+
+    private fun shouldApplyRule(configuration: Configuration, substitutedModule: ModuleComponentSelector): Boolean {
+        var shouldApplyRule = false
+        configuration.incoming.dependencies.forEach { dep ->
+            if (dep.group == substitutedModule.group && dep.name == substitutedModule.module) {
+                shouldApplyRule = true // should apply only if substituted model is in the dependency graph
+            }
+        }
+        return shouldApplyRule
+    }
+
+    private fun transitiveDependenciesRejectTheSubstitutedVersions(project: Project, substitutedModule: ModuleComponentSelector, withSelector: ModuleComponentSelector) {
+        project.dependencies.components.all(TransitiveDependenciesSubstitutionMetadataRule::class.java) {
+            it.params(substitutedModule.group, substitutedModule.module, withSelector.version)
+        }
+    }
+
+    private fun firstLevelDependenciesRejectTheSubstitutedVersions(project: Project, configuration: Configuration, substitutedModule: ModuleComponentSelector,
+                                                                   withSelector: ModuleComponentSelector, resolutionStrategy: ResolutionStrategy) {
+        val logger: Logger = Logging.getLogger(AlignedPlatformRule::class.java)
+        configuration.incoming.beforeResolve { resolvableDependencies ->
+            resolvableDependencies.dependencies.forEach { dep ->
+                if (dep is ExternalModuleDependency) {
+                    if (dep.group!! == substitutedModule.group) { // TODO: had been .startsWith() Which do we want?
+                        val usingDependencyRecommendation = dep.version == null
+
+                        if (usingDependencyRecommendation) {
+                            applyConstraintsToDependencyIfRecommendedVersionMatches(project, dep, substitutedModule, withSelector, logger, configuration)
+                        } else {
+                            applyConstraintsToDependency(dep, substitutedModule, logger, configuration)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun applyConstraintsToDependencyIfRecommendedVersionMatches(project: Project, dep: ExternalModuleDependency, substitutedModule: ModuleComponentSelector, withSelector: ModuleComponentSelector, logger: Logger, configuration: Configuration) {
+        val recommendedVersion = DependencyRecommendationsPlugin().getRecommendedVersionRecursive(project, dep)
+        if (recommendedVersion != null) {
+            val substitutedModuleVersionWithSelector = VersionWithSelector(substitutedModule.version)
+
+            if (substitutedModuleVersionWithSelector.asSelector().accept(recommendedVersion)) {
+                applyConstraintsToDependencyWithRecommendation(dep, withSelector, logger, configuration, substitutedModule)
+            }
+        }
+    }
+
+    private fun applyConstraintsToDependency(dep: ExternalModuleDependency, substitutedModule: ModuleComponentSelector, logger: Logger, configuration: Configuration) {
+        dep.version {
+            it.reject(substitutedModule.version)
+            logger.debug("Rejecting version(s) '${substitutedModule.version}' for incoming dependency '${dep.group}:${dep.name}' " +
+                    "in $configuration before resolution, " +
+                    "based on alignment group '${substitutedModule.group}' " +
+                    "via constraint '$it'")
+        }
+    }
+
+    private fun applyConstraintsToDependencyWithRecommendation(dep: ExternalModuleDependency, withSelector: ModuleComponentSelector, logger: Logger, configuration: Configuration, substitutedModule: ModuleComponentSelector) {
+        dep.version {
+            it.require(withSelector.version) // Define before any "rejects". When defined, overrides previous strictly declaration and clears previous reject.
+            logger.debug("Requiring version ${withSelector.version} for incoming dependency '${dep.group}:${dep.name}' " +
+                    "in $configuration, " +
+                    "based on alignment group '${substitutedModule.group}' " +
+                    "via constraint '$it' because recommended version matched a substitution rule version."
+            )
+            it.reject(substitutedModule.version)
+            logger.debug("Rejecting version(s) '${substitutedModule.version}' for incoming dependency '${dep.group}:${dep.name}' " +
+                    "in $configuration, " +
+                    "based on alignment group '${substitutedModule.group}' " +
+                    "via constraint '$it' because recommended version matched a substitution rule version.")
         }
     }
 }
@@ -98,7 +201,8 @@ data class ReplaceRule(override val module: String, val with: String, override v
     }
 }
 
-data class SubstituteRule(val module: String, val with: String, override var ruleSet: String?, override val reason: String, override val author: String, override val date: String) : BasicRule {
+data class SubstituteRule(val module: String, val with: String, override var ruleSet: String?,
+                          override val reason: String, override val author: String, override val date: String) : BasicRule, Serializable {
     override fun apply(project: Project, configuration: Configuration, resolutionStrategy: ResolutionStrategy, extension: NebulaResolutionRulesExtension, reasons: MutableSet<String>) {
         val substitution = resolutionStrategy.dependencySubstitution
         val selector = substitution.module(module)
@@ -115,7 +219,7 @@ data class SubstituteRule(val module: String, val with: String, override var rul
                     if (requestedSelector.group == selector.group && requestedSelector.module == selector.module) {
                         val versionSelector = VersionWithSelector(selector.version).asSelector()
                         if (versionSelector.accept(requestedSelector.version)) {
-                            val message = "substitution because $reason \n" +
+                            val message = "substitution from '$selector' to '$withSelector' because $reason \n" +
                                     "\twith reasons: ${reasons.joinToString()}"
                             useTarget(withSelector, message)
                         }
@@ -123,12 +227,85 @@ data class SubstituteRule(val module: String, val with: String, override var rul
                 }
             })
         } else {
-            resolutionStrategy.dependencySubstitution {
-                val message = "substitution because $reason \n" +
+            var message = "substitution to '$withSelector' because $reason \n" +
+                    "\twith reasons: ${reasons.joinToString()}"
+
+            val selectorNameSections = selector.displayName.split(":")
+            if (selectorNameSections.size > 2) {
+                val selectorGroupAndArtifact = "${selectorNameSections[0]}:${selectorNameSections[1]}"
+                message = "substitution from '$selectorGroupAndArtifact' to '$withSelector' because $reason \n" +
                         "\twith reasons: ${reasons.joinToString()}"
+            }
+
+            resolutionStrategy.dependencySubstitution {
                 it.substitute(selector)
                         .because(message)
                         .with(withSelector)
+            }
+        }
+    }
+
+    fun applyForAlignedGroup(project: Project, configuration: Configuration, resolutionStrategy: ResolutionStrategy, extension: NebulaResolutionRulesExtension, reasons: MutableSet<String>) {
+        val substitution = resolutionStrategy.dependencySubstitution
+        val selector = substitution.module(module)
+        val withModuleId = ModuleVersionIdentifier.valueOf(with)
+        if (!withModuleId.hasVersion()) {
+            throw SubstituteRuleMissingVersionException(withModuleId, this, reasons)
+        }
+        val withSelector = substitution.module(withModuleId.toString()) as ModuleComponentSelector
+
+        // TODO: only do this if the alignment rule applies to this one via includes and excludes
+        if (selector is ModuleComponentSelector) {
+            resolutionStrategy.dependencySubstitution.all(action {
+                if (requested is ModuleComponentSelector) {
+                    val requestedSelector = requested as ModuleComponentSelector
+                    val requestedWithSubstitutedVersionFromAlignedModule = ModuleVersionIdentifier.valueOf("${requestedSelector.group}:${requestedSelector.module}:${withSelector.version}")
+
+                    if (requestedSelector.group == selector.group) {
+                        val versionSelector = VersionWithSelector(selector.version).asSelector()
+                        if (versionSelector.accept(requestedSelector.version)) {
+                            val message = "substitution from aligned dependency '$selector' to '$withSelector' because '$reason'\n" +
+                                    "\twith reasons: ${reasons.joinToString()}"
+                            val updatedRequestedModuleComponentSelector = substitution.module(requestedWithSubstitutedVersionFromAlignedModule.toString()) as ModuleComponentSelector
+                            useTarget(updatedRequestedModuleComponentSelector, message)
+                        }
+                    }
+                }
+            })
+        } else {
+            // do nothing if there is no version
+        }
+    }
+}
+
+class TransitiveDependenciesSubstitutionMetadataRule : ComponentMetadataRule, Serializable {
+    private val logger: Logger = Logging.getLogger(TransitiveDependenciesSubstitutionMetadataRule::class.java)
+    val substitutionGroup: String
+    val substitutionVersion: String
+    val withSelectorVersion: String
+
+    @Inject
+    constructor(substitutionGroup: String, substitutionVersion: String, withSelectorVersion: String) {
+        this.substitutionGroup = substitutionGroup
+        this.substitutionVersion = substitutionVersion
+        this.withSelectorVersion = withSelectorVersion
+    }
+
+    override fun execute(componentMetadataContext: ComponentMetadataContext?) {
+        modifyDetails(componentMetadataContext!!.details)
+    }
+
+    private fun modifyDetails(details: ComponentMetadataDetails) {
+        details.allVariants {
+            it.withDependencies { deps ->
+                deps.forEach { dep ->
+                    if (dep.group == substitutionGroup) { // TODO: had been .startsWith()
+                        dep.version {
+                            it.reject(substitutionVersion)
+                            logger.debug("Rejection of group '$substitutionGroup' and version $substitutionVersion")
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Introduce the AlignedPlatformRule to apply substitution rules to all aligned artifacts when the substitutions are applicable. (Note: this requires that the artifact originally mentioned in the substitution rule is actually in the dependency graph). This will apply to direct and transitive dependencies.

This also takes dependency recommendations into consideration, and will provide a suggested version to replace a problematic recommendation.