### PR TITLE
Update aligned platform rules

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
@@ -1,6 +1,5 @@
 package nebula.plugin.resolutionrules
 
-
 import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
@@ -1544,6 +1543,154 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         coreAlignment | resultingVersion
         false         | "1.0.2"
         true          | "1.0.2"
+    }
+
+
+    @Unroll
+    def 'multiple substitutions applied: recs with core bom support disabled: core alignment should honor multiple substitutions | core alignment: #coreAlignment'() {
+        given:
+        def bomVersion = "1.0.1"
+        setupForBomAndAlignmentAndSubstitution(bomVersion, "")
+
+        rulesJsonFile.delete()
+        rulesJsonFile.createNewFile()
+        createMultipleSubstitutionRules()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+
+            assert result.output.contains("require version 1.0.2")
+            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
+            assert result.output.contains("rejection of version(s) '1.0.3'")
+            assert result.output.contains("rejection of version(s) '1.1.0'")
+//            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | coreBomSupport | resultingVersion
+        false         | false          | "1.0.1"
+        true          | false          | "1.0.2"
+    }
+
+    @Unroll
+    def 'multiple substitutions applied: recs with core bom support enabled: alignment styles should honor multiple substitutions | core alignment: #coreAlignment'() {
+        given:
+        def bomVersion = "1.0.1"
+        setupForBomAndAlignmentAndSubstitution(bomVersion, "")
+
+        rulesJsonFile.delete()
+        rulesJsonFile.createNewFile()
+        createMultipleSubstitutionRules()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+
+            assert result.output.contains("require version 1.0.2")
+            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
+            assert result.output.contains("rejection of version(s) '1.0.3'")
+            assert result.output.contains("rejection of version(s) '1.1.0'")
+            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | coreBomSupport | resultingVersion
+        false         | true           | "1.0.2"
+        true          | true           | "1.0.2"
+    }
+
+
+    @Unroll
+    def 'multiple substitutions applied: enforced recs with core bom support disabled: core alignment should honor multiple substitutions | core alignment: #coreAlignment'() {
+        given:
+        def bomVersion = "1.0.1"
+        def usingEnforcedPlatform = true
+        setupForBomAndAlignmentAndSubstitution(bomVersion, "", usingEnforcedPlatform)
+
+        rulesJsonFile.delete()
+        rulesJsonFile.createNewFile()
+        createMultipleSubstitutionRules()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+
+            assert result.output.contains("require version 1.0.2")
+            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
+            assert result.output.contains("rejection of version(s) '1.0.3'")
+            assert result.output.contains("rejection of version(s) '1.1.0'")
+//            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | coreBomSupport | resultingVersion
+        false         | false          | "1.0.1"
+        true          | false          | "1.0.2"
+    }
+
+    @Unroll
+    def 'multiple substitutions applied: enforced recs with core bom support enabled: alignment styles should honor multiple substitutions | core alignment: #coreAlignment'() {
+        given:
+        def bomVersion = "1.0.1"
+        def usingEnforcedPlatform = true
+        setupForBomAndAlignmentAndSubstitution(bomVersion, "", usingEnforcedPlatform)
+
+        rulesJsonFile.delete()
+        rulesJsonFile.createNewFile()
+        createMultipleSubstitutionRules()
+
+        when:
+        def result = runTasks(*tasks(coreAlignment, coreBomSupport))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+
+            assert result.output.contains("require version 1.0.2")
+            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
+            assert result.output.contains("rejection of version(s) '1.0.3'")
+            assert result.output.contains("rejection of version(s) '1.1.0'")
+            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
+        }
+
+        where:
+        coreAlignment | coreBomSupport | resultingVersion
+        false         | true           | "1.0.2"
+        true          | true           | "1.0.2"
     }
 
     private File createMultipleSubstitutionRules() {

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -159,7 +159,7 @@ class AlignedPlatformRule(alignRule: AlignRule, substituteRules: MutableList<Sub
         if (!alreadyRejectedThisVersion(dep.versionConstraint, substitutedModule.version) &&
                 !alreadyRequiredThisVersion(dep.versionConstraint, requiredVersion)) {
 
-            val reason = "require version ${withSelector.version} and rejection of version(s) '${substitutedModule.version}'" +
+            val reason = "require version ${withSelector.version} and rejection of BOM recommended version(s) '${substitutedModule.version}' " +
                     "for incoming dependency '${dep.group}:${dep.name}' " +
                     "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}' " +
                     "because recommended version matched a substitution rule version."

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -81,7 +81,7 @@ data class RuleSet(
     }
 }
 
-class AlignedPlatformRule(alignRule: AlignRule, substituteRules: MutableList<SubstituteRule>) : Serializable {
+class AlignedPlatformRule(alignRule: AlignRule, substituteRules: MutableList<SubstituteRule>) : CanRejectDependency, Serializable {
     var substituteRules: List<SubstituteRule> = substituteRules
     var alignRule: AlignRule = alignRule
 
@@ -143,25 +143,28 @@ class AlignedPlatformRule(alignRule: AlignRule, substituteRules: MutableList<Sub
     }
 
     private fun applyConstraintsToDependency(dep: ExternalModuleDependency, substitutedModule: ModuleComponentSelector, configuration: Configuration) {
-        dep.version {
-            it.reject(substitutedModule.version)
+        if (!alreadyRejectedThisVersion(dep.versionConstraint, substitutedModule.version)) {
+
+            val reason = "rejection of version(s) '${substitutedModule.version}' for incoming dependency '${dep.group}:${dep.name}' " +
+                    "before resolution, " +
+                    "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}'"
+            rejectVersion(dep, substitutedModule.version, reason)
         }
-        dep.because("rejection of version(s) '${substitutedModule.version}' for incoming dependency '${dep.group}:${dep.name}' " +
-                "in $configuration before resolution, " +
-                "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}' ")
     }
 
     private fun applyConstraintsToDependencyWithRecommendation(dep: ExternalModuleDependency, withSelector: ModuleComponentSelector,
                                                                configuration: Configuration, substitutedModule: ModuleComponentSelector) {
-        dep.version {
-            it.require(withSelector.version) // Define before any "rejects". When defined, overrides previous strictly declaration and clears previous reject.
-            it.reject(substitutedModule.version)
+        val requiredVersion = withSelector.version
+
+        if (!alreadyRejectedThisVersion(dep.versionConstraint, substitutedModule.version) &&
+                !alreadyRequiredThisVersion(dep.versionConstraint, requiredVersion)) {
+
+            val reason = "require version ${withSelector.version} and rejection of version(s) '${substitutedModule.version}'" +
+                    "for incoming dependency '${dep.group}:${dep.name}' " +
+                    "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}' " +
+                    "because recommended version matched a substitution rule version."
+            rejectVersion(dep, substitutedModule.version, reason, requiredVersion)
         }
-        dep.because("require version ${withSelector.version} and rejection of version(s) '${substitutedModule.version}'" +
-                "for incoming dependency '${dep.group}:${dep.name}' " +
-                "in $configuration, " +
-                "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}' " +
-                "because recommended version matched a substitution rule version.\n")
     }
 }
 
@@ -276,7 +279,7 @@ data class SubstituteRule(val module: String, val with: String, override var rul
     }
 }
 
-class TransitiveDependenciesSubstitutionMetadataRule : ComponentMetadataRule, Serializable {
+class TransitiveDependenciesSubstitutionMetadataRule : CanRejectDependency, ComponentMetadataRule, Serializable {
     val alignRule: AlignRule
     val substitutionGroup: String
     val substitutionModuleName: String
@@ -301,11 +304,12 @@ class TransitiveDependenciesSubstitutionMetadataRule : ComponentMetadataRule, Se
         details.allVariants {
             it.withDependencies { deps ->
                 deps.forEach { dep ->
-                    if (alignRule.ruleMatches(dep.group ?: "", dep.name)) {
-                        dep.version {
-                            it.reject(substitutionVersion)
-                        }
-                        dep.because("rejection of transitive dependency ${dep.group}:${dep.name} version(s) '$substitutionVersion' from aligned dependency '$substitutionGroup:$substitutionModuleName'")
+                    if (alignRule.ruleMatches(dep.group ?: "", dep.name)
+                            && !alreadyRejectedThisVersion(dep.versionConstraint, substitutionVersion)) {
+
+                        val reason = "rejection of transitive dependency ${dep.group}:${dep.name} version(s) " +
+                                "'$substitutionVersion' from aligned dependency '$substitutionGroup:$substitutionModuleName'"
+                        rejectVersion(dep, substitutionVersion, reason)
                     }
                 }
             }
@@ -370,6 +374,62 @@ class DependencyDeniedException(moduleId: ModuleVersionIdentifier, rule: DenyRul
 
 class SubstituteRuleMissingVersionException(moduleId: ModuleVersionIdentifier, rule: SubstituteRule, reasons: MutableSet<String>) : Exception("The dependency to be substituted ($moduleId) must have a version. Invalid rule: $rule\n" +
         "\twith reasons: ${reasons.joinToString()}")
+
+interface CanRejectDependency {
+    fun rejectVersion(dep: DirectDependencyMetadata, newVersionToReject: String, newReason: String, requiredVersion: String? = null) {
+        val rejectedVersions = mutableSetOf<String>()
+        val reasons = mutableSetOf<String>()
+        if (dep.reason != null) {
+            reasons.addAll(dep.reason!!.split("\n"))
+        }
+        dep.version {
+            rejectedVersions.addAll(it.rejectedVersions)
+        }
+
+        // reset values
+        if (requiredVersion != null) {
+            dep.version {
+                it.require(requiredVersion) // Define before any "rejects". When defined, overrides previous strictly declaration and clears previous reject.
+            }
+        }
+        dep.version {
+            rejectedVersions.add(newVersionToReject)
+            it.reject(*(rejectedVersions.sorted().toTypedArray()))
+        }
+        reasons.add(newReason)
+        dep.because(reasons.sorted().joinToString("\n"))
+    }
+
+    fun rejectVersion(dep: ExternalModuleDependency, newVersionToReject: String, newReason: String, requiredVersion: String? = null) {
+        val rejectedVersions = mutableSetOf<String>()
+        val reasons = mutableSetOf<String>()
+        if (dep.reason != null) {
+            reasons.addAll(dep.reason!!.split("\n"))
+        }
+        dep.version {
+            rejectedVersions.addAll(it.rejectedVersions)
+        }
+
+        // reset values
+        if (requiredVersion != null) {
+            dep.version {
+                it.require(requiredVersion) // Define before any "rejects". When defined, overrides previous strictly declaration and clears previous reject.
+            }
+        }
+        dep.version {
+            rejectedVersions.add(newVersionToReject)
+            it.reject(*(rejectedVersions.sorted().toTypedArray()))
+        }
+        reasons.add(newReason)
+        dep.because(reasons.sorted().joinToString("\n"))
+    }
+
+    fun alreadyRejectedThisVersion(versionConstraint: VersionConstraint, versionToReject: String) =
+            versionConstraint.rejectedVersions.contains(versionToReject)
+
+    fun alreadyRequiredThisVersion(versionConstraint: VersionConstraint, versionToRequire: String) =
+            versionConstraint.requiredVersion == versionToRequire
+}
 
 fun Configuration.exclude(group: String, module: String) {
     exclude(mapOf("group" to group, "module" to module))


### PR DESCRIPTION
When core alignment is enabled, the rejections that comes from a substitution rule applied to an aligned group will additively reject the "substitute-away-from" version
