### PR TITLE
Reject in substitution rule

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
@@ -39,6 +39,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                 .addModule('test.nebula:a:1.1.0')
 
                 .addModule('test.nebula:b:0.5.0')
+                .addModule('test.nebula:b:0.6.0')
 
                 .addModule('test.nebula:b:1.0.0')
                 .addModule('test.nebula:b:1.0.1')
@@ -81,8 +82,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'statically defined dependency: alignment styles should substitute and align from static version to higher static version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -104,8 +105,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'statically defined dependency: alignment styles should substitute and align from static version to higher latest.release dynamic version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -127,8 +128,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'statically defined dependency: alignment styles should substitute and align from static version to higher minor-scoped dynamic version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -148,10 +149,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'statically defined dependency: core alignment should substitute and align from static version to lower substitute-to version | core alignment: #coreAlignment'() {
+    def 'statically defined dependency: alignment styles should substitute and align from static version to lower substitute-to version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -166,15 +167,15 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "static version"      | "1.0.1"               | "1.0.0"             | "lower"            | false         | "1.0.1"
+        "static version"      | "1.0.1"               | "1.0.0"             | "lower"            | false         | "1.0.0"
         "static version"      | "1.0.1"               | "1.0.0"             | "lower"            | true          | "1.0.0"
     }
 
     @Unroll
     def 'statically defined dependency: alignment styles should substitute and align from range to higher static version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -196,8 +197,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'statically defined dependency: alignment styles should substitute and align from range to higher latest.release dynamic version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -217,10 +218,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'statically defined dependency: alignment styles should substitute and align from range to higher major-scoped dynamic version | core alignment: #coreAlignment'() {
+    def 'statically defined dependency: alignment styles should substitute and align from range to higher minor-scoped dynamic version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -242,8 +243,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'statically defined dependency: alignment styles should substitute and align from range to higher static version with higher minor version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -263,10 +264,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'statically defined dependency: core alignment should substitute and align from range to lower substitute-to version | core alignment: #coreAlignment'() {
+    def 'statically defined dependency: alignment styles should substitute and align from range to lower substitute-to version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.1"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.1', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -281,15 +282,15 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "range"               | "[1.0.1,1.0.2]"       | "1.0.0"             | "lower"            | false         | "1.0.1"
+        "range"               | "[1.0.1,1.0.2]"       | "1.0.0"             | "lower"            | false         | "1.0.0"
         "range"               | "[1.0.1,1.0.2]"       | "1.0.0"             | "lower"            | true          | "1.0.0"
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher static version that is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to higher static version that is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -304,15 +305,15 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | false         | "1.0.3"
-        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | true          | "1.0.2"
+        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | false         | "1.0.3" // FIXME: should resolve differently
+        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | true          | "1.0.3" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher latest.release dynamic version in narrow definition that is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to higher latest.release dynamic version in narrow definition that is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -327,15 +328,15 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | false         | "1.0.3"
-        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | true          | "1.0.2"
+        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | false         | "1.0.3" // FIXME: should resolve differently
+        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | true          | "1.0.3" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher major-scoped dynamic version that is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to higher minor-scoped dynamic version that is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -350,15 +351,15 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "static version"      | "1.0.3"               | "1.+"               | "higher"           | false         | "1.0.3"
-        "static version"      | "1.0.3"               | "1.+"               | "higher"           | true          | "1.0.2"
+        "static version"      | "1.0.3"               | "1.+"               | "higher"           | false         | "1.0.3" // FIXME: should resolve differently
+        "static version"      | "1.0.3"               | "1.+"               | "higher"           | true          | "1.0.3" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to conflict-resolved version that is is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to conflict-resolved version that is is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -373,15 +374,15 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | false         | "1.0.3"
-        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | true          | "1.0.2"
+        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | false         | "1.0.3" // FIXME: should resolve differently
+        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | true          | "1.0.3" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
     def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher static version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -403,8 +404,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher latest.release dynamic version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -424,10 +425,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher static version with higher minor version | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to higher minor-scoped static version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -447,10 +448,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: core alignment should substitute and align from range to lower substitute-to version | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from range to lower substitute-to version | core alignment: #coreAlignment'() {
         given:
-        def dependencyDefinitionVersion = "1.0.+"
-        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersion)
+        List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
+        setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -465,14 +466,63 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
-        "range"               | "(,1.1.0)"            | "0.5.0"             | "lower"            | false         | "1.0.3"
+        "range"               | "(,1.1.0)"            | "0.5.0"             | "lower"            | false         | "0.5.0"
         "range"               | "(,1.1.0)"            | "0.5.0"             | "lower"            | true          | "0.5.0"
     }
 
     @Unroll
-    def 'missing cases: statically defined dependency: core alignment fails to align when lower versions are missing | core alignment: #coreAlignment'() {
+    def 'missing cases: statically defined dependency: alignment styles fail to align when lower versions are missing | core alignment: #coreAlignment'() {
         given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", AResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", BResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$BResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | AResultingVersion | BResultingVersion | CResultingVersion
+        "static version"   | "1.0.1"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | false         | "0.5.0"           | '0.6.0'           | "FAILED"
+        "static version"   | "1.0.1"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | true          | "0.5.0"           | '0.6.0'           | "FAILED"
+    }
+
+    @Unroll
+    def 'missing cases: statically defined dependency: alignment styles fail to align when higher versions are missing | core alignment: #coreAlignment'() {
+        given:
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
+
+        when:
+        def result = runTasks(*tasks(coreAlignment))
+
+        then:
+        dependencyInsightContains(result.output, "test.nebula:a", AResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", BResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$CResultingVersion")
+        }
+
+        where:
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | AResultingVersion | BResultingVersion | CResultingVersion
+        "static version"   | "1.0.1"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | false         | "FAILED"          | '0.6.0'           | "1.4.0"
+        "static version"   | "1.0.1"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | true          | "FAILED"          | '0.6.0'           | "1.4.0"
+    }
+
+    @Unroll
+    def 'missing cases: dynamically defined dependency: alignment styles should fail to align when dynamic dependency definition and substitutions leave no viable versions | core alignment: #coreAlignment'() {
+        given:
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -482,20 +532,21 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
         dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
 
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$CResultingVersion")
         }
 
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "static version"   | "1.0.1"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | false         | "1.0.1"            | "1.0.1"
-        "static version"   | "1.0.1"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | true          | "0.5.0"            | "FAILED"
+        "range"            | "1.+"          | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | false         | "1.1.0"            | "1.4.0" // FIXME: should resolve differently
+        "range"            | "1.+"          | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | true          | "1.1.0"            | "1.4.0" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'missing cases: statically defined dependency: core alignment fails to align when higher versions are missing | core alignment: #coreAlignment'() {
+    def 'missing cases: dynamically defined dependency: alignment styles should fail to align when dynamic latest.release dependency definition and substitutions leave no viable versions for some lower aligned versions | core alignment: #coreAlignment'() {
         given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -505,66 +556,21 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
         dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
 
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
-        }
-
-        where:
-        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "static version"   | "1.0.1"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | false         | "1.1.0"            | "1.4.0"
-        "static version"   | "1.0.1"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"           | "1.4.0"
-    }
-
-    @Unroll
-    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions | core alignment: #coreAlignment'() {
-        given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
-
-        when:
-        def result = runTasks(*tasks(coreAlignment))
-
-        then:
-        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
-
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
-        }
-
-        where:
-        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "range"            | "1.+"          | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | false         | "1.1.0"            | "1.4.0"
-        "range"            | "1.+"          | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | true          | "FAILED"           | "FAILED"
-    }
-
-    @Unroll
-    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
-        given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
-
-        when:
-        def result = runTasks(*tasks(coreAlignment))
-
-        then:
-        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
-
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$CResultingVersion")
         }
 
         where:
         definedVersionType | definedVersion   | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "range"            | "latest.release" | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | false         | "1.1.0"            | "1.4.0"
-        "range"            | "latest.release" | "range"        | "b:[1.0.0,)"            | "b:0.5.0"             | "lower"     | true          | "0.5.0"            | "FAILED"
+        "range"            | "latest.release" | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | false         | "1.1.0"            | "1.4.0" // FIXME: should resolve differently
+        "range"            | "latest.release" | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | true          | "1.1.0"            | "1.4.0" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
+    def 'missing cases: dynamically defined dependency: alignment styles should fail to align when dependency dynamic definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
         given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
@@ -574,69 +580,70 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
         dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
 
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$CResultingVersion")
         }
 
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | false         | "1.1.0"            | "1.4.0"
-        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"           | "1.4.0"
+        "range"            | "1.+"          | "range"        | "[1.0.0,1.2.0)"         | "1.4.0"               | "higher"    | false         | "1.1.0"            | "1.4.0" // FIXME: should resolve differently
+        "range"            | "1.+"          | "range"        | "[1.0.0,1.2.0)"         | "1.4.0"               | "higher"    | true          | "1.1.0"            | "1.4.0" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'missing cases: narrowly defined dynamic dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
+    def 'missing cases: narrowly defined dynamic dependency: alignment styles should fail to resolve when narrow dynamic dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
         given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
 
         then:
-        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:a", ABCResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABCResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", ABCResultingVersion)
 
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABCResultingVersion")
         }
 
         where:
-        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "narrow range"     | "1.0.+"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | false         | "1.0.3"            | "1.0.3"
-        "narrow range"     | "1.0.+"        | "range"        | "b:[1.0.0,1.1.0)"       | "b:0.5.0"             | "lower"     | true          | "FAILED"           | "FAILED"
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABCResultingVersion
+        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | false         | "1.0.3" // FIXME: should resolve differently
+        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | true          | "1.0.3" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'missing cases: narrowly defined dynamic dependency: core alignment fails to align when dependency definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
+    def 'missing cases: narrowly defined dynamic dependency: core alignment fails to align when narrow dynamic dependency definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
         given:
-        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, definedVersion)
+        List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
+        setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
 
         when:
         def result = runTasks(*tasks(coreAlignment))
 
         then:
-        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:a", ABCResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", ABCResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", ABCResultingVersion)
 
-        if (coreAlignment && ABResultingVersion != "FAILED" && CResultingVersion != "FAILED") {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABResultingVersion")
+        if (coreAlignment) {
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABCResultingVersion")
         }
 
         where:
-        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "narrow range"     | "1.0.+"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | false         | "1.0.3"            | "1.0.3"
-        "narrow range"     | "1.0.+"        | "range"        | "c:[1.0.0,1.1.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"           | "FAILED"
+        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABCResultingVersion
+        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | false         | "1.0.3" // FIXME: should resolve differently
+        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | true          | "1.0.3" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'should still apply substitution to group if the specified dependency is not in the graph | core alignment: #coreAlignment'() {
-        // Note: this may be controversial
+    def 'should not apply substitution to modules not listed in substitution rule | core alignment: #coreAlignment'() {
         given:
         def module = "test.nebula:$subFromVersionAndModule"
         def with = "test.nebula:$subToVersionAndModule"
-        createAlignAndSubstituteRule(module, with)
+        createAlignAndSubstituteRule([(module.toString()): with])
 
         buildFile << """
             dependencies {
@@ -658,8 +665,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | resultingVersion
-        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | false         | "1.1.0"
-        "range"            | "1.+"          | "range"        | "c:[1.0.0,1.2.0)"       | "c:1.4.0"             | "higher"    | true          | "FAILED"
+        "range"            | "1.+"          | "range"        | "a:[1.0.0,1.2.0)"       | "a:0.5.0"             | "lower"     | false         | "1.1.0" // FIXME: A & B could resolve differently
+        "range"            | "1.+"          | "range"        | "a:[1.0.0,1.2.0)"       | "a:0.5.0"             | "lower"     | true          | "1.1.0" // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
@@ -667,7 +674,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         given:
         def module = "test.beverage:d:1.0.0"
         def with = "test.nebula:b:latest.release"
-        createAlignAndSubstituteRule(module, with)
+        createAlignAndSubstituteRule([(module.toString()): with])
 
         buildFile << """
             dependencies {
@@ -695,14 +702,19 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     @Unroll
     def 'substitute all versions for another dependency with static version and align direct and transitives higher | core alignment #coreAlignment'() {
         given:
-        def module = "test.other:e"
-        def with = "test.nebula:b:1.1.0"
-        createAlignAndSubstituteRule(module, with)
+        def graph = new DependencyGraphBuilder()
+                .addModule(new ModuleBuilder('test.other:h:1.0.0').addDependency('test.nebula:b:1.0.2').build())
+                .build()
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        def module = "test.other:g"
+        def with = "test.other:h:1.0.0"
+        createAlignAndSubstituteRule([(module.toString()): with])
 
         buildFile << """
             dependencies {
-                compile 'test.other:e:1.0.0'
-                compile 'test.nebula:a:1.0.0'
+                compile 'test.other:g:1.0.0'
+                compile 'test.nebula:a:1.1.0'
             }
             """.stripIndent()
 
@@ -710,42 +722,9 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment))
 
         then:
-        result.output.contains('test.other:e:1.0.0 -> test.nebula:b:1.1.0')
-        result.output.contains('test.nebula:a:1.0.0 -> 1.1.0')
-
         def resultingVersion = "1.1.0"
-        dependencyInsightContains(result.output, "test.other:e:1.0.0 -> test.nebula:b", resultingVersion)
         dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
-
-        if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
-        }
-
-        where:
-        coreAlignment << [false, true]
-    }
-
-    @Unroll
-    def 'substitute all versions for another dependency with static version and align direct and transitives lower | core alignment #coreAlignment'() {
-        given:
-        def module = "test.other:e"
-        def with = "test.nebula:b:1.0.3"
-        createAlignAndSubstituteRule(module, with)
-
-        buildFile << """
-            dependencies {
-                compile 'test.other:e:1.0.0'
-                compile 'test.nebula:a:1.0.0'
-            }
-            """.stripIndent()
-
-        when:
-        def result = runTasks(*tasks(coreAlignment))
-
-        then:
-        def resultingVersion = "1.0.3"
-        dependencyInsightContains(result.output, "test.other:e:1.0.0 -> test.nebula:b", resultingVersion)
-        dependencyInsightContains(result.output, "test.nebula", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -795,7 +774,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'only brought in transitively: core alignment should substitute and align from static version to lower static version that is not substituted-away-from | core alignment #coreAlignment'() {
+    def 'only brought in transitively: alignment styles should substitute and align from static version to lower static version that is not substituted-away-from | core alignment #coreAlignment'() {
         given:
         def graph = new DependencyGraphBuilder()
                 .addModule(new ModuleBuilder('test.other:brings-a:1.0.0').addDependency('test.nebula:a:1.0.2').build())
@@ -804,9 +783,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                 .build()
         mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
 
-        def module = "test.nebula:a:[1.0.2,1.1.0]"
-        def with = "test.nebula:a:1.0.1"
-        createAlignAndSubstituteRule(module, with)
+        def substituteFromVersion = "[1.0.2,1.1.0]"
+        def substituteToVersion = "1.0.1"
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:b:$substituteFromVersion".toString(), "test.nebula:b:$substituteToVersion".toString())
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         buildFile << """
             dependencies {
@@ -829,12 +811,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | resultingVersion
-        false         | "1.0.3"
+        false         | "1.0.1"
         true          | "1.0.1"
     }
 
     @Unroll
-    def 'only brought in transitively: core alignment should substitute and align #description | core alignment #coreAlignment'() {
+    def 'only brought in transitively: core alignment fails with matching static substitution and force: #description | core alignment #coreAlignment'() {
         given:
         def graph = new DependencyGraphBuilder()
                 .addModule(new ModuleBuilder('test.other:brings-a:1.0.0').addDependency('test.nebula:a:1.0.3').build())
@@ -843,13 +825,19 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                 .build()
         mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
 
-        def module = "test.nebula:a:1.0.3"
-        def with = "test.nebula:a:1.1.0"
-        createAlignAndSubstituteRule(module, with)
+        def substituteFromVersion = "1.0.3"
+        def substituteToVersion = "1.1.0"
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:b:$substituteFromVersion".toString(), "test.nebula:b:$substituteToVersion".toString())
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         def forceConfig = ''
         if (useForce) {
-            forceConfig = "force 'test.nebula:a:$forcedVersion'"
+            forceConfig = """
+                force 'test.nebula:a:$forcedVersion'
+                force 'test.nebula:b:$forcedVersion'
+                """.stripIndent()
         }
 
         buildFile << """
@@ -867,33 +855,27 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment))
 
         then:
-        if (!needsWorkToFix) {
-            dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
-            dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
-        } else {
-            dependencyInsightContains(result.output, "test.nebula:a", 'FAILED')
-            dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
-        }
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
-        if (coreAlignment) {
+        if (coreAlignment && resultingVersion != 'FAILED') {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
 
         where:
-        coreAlignment | useForce | forcedVersion    | resultingVersion | description                  | needsWorkToFix
-        false         | false    | null             | '1.1.0'          | 'without a force'            | false
-        false         | true     | '1.0.3'          | '1.0.3'          | 'forced to static version'   | false
-        false         | true     | 'latest.release' | '1.1.0'          | 'forced to latest.release'   | false
+        coreAlignment | useForce | forcedVersion    | resultingVersion | description
+        false         | false    | null             | '1.1.0'          | 'without a force'
+        false         | true     | '1.0.3'          | '1.0.3'          | 'forced to static version'
+        false         | true     | 'latest.release' | '1.1.0'          | 'forced to latest.release'
 
-        true          | false    | null             | '1.1.0'          | 'without a force'            | false
-        true          | true     | '1.1.0'          | '1.1.0'          | 'forced to a static version' | false
-
+        true          | false    | null             | '1.1.0'          | 'without a force'
 //         TODO: possibly use require-reject in lieu of resolutionStrategy.dependencySubstitution to fix this case
-        true          | true     | 'latest.release' | '1.1.0'          | 'forced to latest.release'   | true
+        true          | true     | '1.0.2'          | 'FAILED'         | 'forced to a static version'
+        true          | true     | 'latest.release' | 'FAILED'         | 'forced to latest.release'
     }
 
     @Unroll
-    def 'only brought in transitively: core alignment should substitute with a range and align with a force | core alignment #coreAlignment'() {
+    def 'only brought in transitively: alignment styles should substitute with a range and align with a force | core alignment #coreAlignment'() {
         given:
         def graph = new DependencyGraphBuilder()
                 .addModule(new ModuleBuilder('test.other:brings-a:1.0.0').addDependency('test.nebula:a:1.0.2').build())
@@ -902,9 +884,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                 .build()
         mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
 
-        def module = "test.nebula:a:[1.0.2,1.1.0]"
-        def with = "test.nebula:a:1.0.1"
-        createAlignAndSubstituteRule(module, with)
+        def substituteFromVersion = "[1.0.2,1.1.0]"
+        def substituteToVersion = "1.0.1"
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:b:$substituteFromVersion".toString(), "test.nebula:b:$substituteToVersion".toString())
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         buildFile << """
             dependencies {
@@ -915,6 +900,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
             configurations.all {
                 resolutionStrategy {
                     force 'test.nebula:a:latest.release'
+                    force 'test.nebula:b:latest.release'
                 }
             }
             """.stripIndent()
@@ -932,16 +918,18 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | resultingVersion
-        false         | "1.0.3"
+        false         | "1.0.1"
         true          | "1.0.1"
     }
 
     @Unroll
-    def 'apply a static version via details.useVersion and align results #description | core alignment #coreAlignment'() {
-        // This is not using a substitution rule, so alignment is not totally taking place, as some versions are not rejected
-        // TODO: See about reading in the resolution strategies to catch cases like this
-
+    def 'apply a static version via details.useVersion and align results | core alignment #coreAlignment'() {
         given:
+        def graph = new DependencyGraphBuilder()
+                .addModule(new ModuleBuilder('test.other:brings-a:1.0.0').addDependency('test.nebula:a:1.0.2').build())
+                .build()
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
         rulesJsonFile << """
             {
                 "align": [
@@ -952,13 +940,13 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         buildFile << """
             dependencies {
-                compile 'test.nebula:a:1.0.3'
+                compile 'test.other:brings-a:1.0.0'
                 compile 'test.nebula:b:1.0.0'
                 compile 'test.nebula:c:1.0.3'
             }
             configurations.all {
                 resolutionStrategy.eachDependency { details ->
-                    if (details.requested.name == 'a') {
+                    if (details.requested.group == 'test.nebula') {
                         details.useVersion '1.0.1'
                         details.because('$reason')
                     }
@@ -971,19 +959,18 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment))
 
         then:
-        dependencyInsightContains(result.output, "test.nebula:a", resultingVersionForConstrainedVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", resultingVersionForNonConstrainedVersion)
-        dependencyInsightContains(result.output, "test.nebula:c", resultingVersionForNonConstrainedVersion)
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:c", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersionForNonConstrainedVersion")
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
 
-
         where:
-        coreAlignment | resultingVersionForConstrainedVersion | resultingVersionForNonConstrainedVersion | description
-        false         | "1.0.3"                               | "1.0.3"                                  | "aligns all dependencies"
-        true          | "1.0.1"                               | "1.0.3"                                  | "does not align all dependencies"
+        coreAlignment | resultingVersion
+        false         | "1.0.1"
+        true          | "1.0.1"
     }
 
     @Unroll
@@ -1002,8 +989,6 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "com.google.inject:guice", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("com.google.inject:guice:{require 4.1.0; reject [4.2.0,)}")
-
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-com.google.inject:$resultingVersion")
         }
 
@@ -1017,45 +1002,47 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     def 'dynamically defined dependency: core alignment substitutes all versions higher than x and aligns | core alignment #coreAlignment'() {
         given:
         // based on https://github.com/nebula-plugins/gradle-nebula-integration/issues/50
+        // Also, substitutions apply on declared dependencies, not resolved ones
         setupForGuiceAndLibraryDependency(definedVersion)
 
         when:
         def result = runTasks(*tasks(coreAlignment, false, 'com.google.inject'))
 
         then:
-        dependencyInsightContains(result.output, "com.google.inject.extensions:guice-assistedinject", resultingAlignedVersion)
-        dependencyInsightContains(result.output, "com.google.inject.extensions:guice-grapher", resultingAlignedVersion)
-        dependencyInsightContains(result.output, "com.google.inject.extensions:guice-multibindings", resultingAlignedVersion)
+        dependencyInsightContains(result.output, "com.google.inject.extensions:guice-assistedinject", resultingVersion)
+        dependencyInsightContains(result.output, "com.google.inject.extensions:guice-grapher", resultingVersion)
+        dependencyInsightContains(result.output, "com.google.inject.extensions:guice-multibindings", resultingVersion)
 
-        if (resultingNonAlignedVersion != null) {
+        if (!guiceIsSubstituted) {
             // since this test uses an external dependency that keeps incrementing, let's check that it just doesn't get the same result
-            def content = "com.google.inject:guice:.*$resultingAlignedVersion\n"
+            def content = "com.google.inject:guice:.*$resultingVersion\n"
             assert result.output.findAll(content).size() == 0
 
             // just make sure there's a value here for dependencyInsight
             dependencyInsightContains(result.output, "com.google.inject:guice", '')
-        } else {
-            dependencyInsightContains(result.output, "com.google.inject:guice", resultingAlignedVersion)
         }
 
         if (coreAlignment) {
             assert result.output.contains("com.google.inject:guice:{require 4.1.0; reject [4.2.0,)}")
 
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-com.google.inject:$resultingAlignedVersion")
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-com.google.inject:$resultingVersion")
         }
 
         where:
-        coreAlignment | definedVersion | resultingAlignedVersion | resultingNonAlignedVersion
-        false         | '4.+'          | '4.1.0'                 | '4.2.2'
-        true          | '4.+'          | '4.1.0'                 | null
+        coreAlignment | definedVersion | resultingVersion | guiceIsSubstituted
+        false         | '4.+'          | '4.1.0'          | false // FIXME: should resolve differently
+        true          | '4.+'          | '4.1.0'          | false // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'transitive dependencies are aligned with same constraints as direct dependencies | core alignment #coreAlignment'() {
+    def 'transitive dependencies are aligned with constraints | core alignment #coreAlignment'() {
         given:
-        def module = "test.nebula:f:[1.0.1,1.1.0)"
-        def with = "test.nebula:f:1.0.0"
-        createAlignAndSubstituteRule(module, with)
+        def substituteFromVersion = "[1.0.1,1.1.0)"
+        def substituteToVersion = "1.0.0"
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:f:$substituteFromVersion".toString(), "test.nebula:f:$substituteToVersion".toString())
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         buildFile << """
             dependencies {
@@ -1073,7 +1060,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         if (coreAlignment) {
             // for direct dependency
-            assert result.output.contains("test.nebula:f:{require 1.0.3; reject [1.0.1,1.1.0)}")
+            // assert result.output.contains("test.nebula:f:{require 1.0.3; reject [1.0.1,1.1.0)}")
 
             // for transitive dependencies
             assert result.output.contains("test.nebula:a:{require 1.0.0; reject [1.0.1,1.1.0)}")
@@ -1086,16 +1073,16 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'substitution rule excludes are honored | core alignment #coreAlignment'() {
+    def 'alignment rule excludes are honored | core alignment #coreAlignment'() {
         given:
-        def module = "test.nebula:a:[1.0.0,1.0.3)"
-        def with = "test.nebula:a:1.0.3"
+        def module = "[1.0.1,1.0.3)"
+        def with = "1.0.3"
         rulesJsonFile << """
             {
                 "substitute": [
                     {
-                        "module" : "$module",
-                        "with" : "$with",
+                        "module" : "test.nebula:b:$module",
+                        "with" : "test.nebula:b:$with",
                         "reason" : "$reason",
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
@@ -1107,7 +1094,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                         "reason": "Align test.nebula dependencies",
                         "author": "Example Person <person@example.org>",
                         "includes": [],
-                        "excludes": ["(b|c)"],
+                        "excludes": ["(c|g)"],
                         "date": "2016-03-17T20:21:20.368Z"
                     }
                 ]
@@ -1116,7 +1103,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         buildFile << """
             dependencies {
-                compile 'test.nebula:a:1.0.1'
+                compile 'test.nebula:a:1.0.0'
                 compile 'test.nebula:b:1.0.1'
                 compile 'test.nebula:c:1.0.2'
                 compile 'test.nebula:g:1.0.1'
@@ -1129,10 +1116,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         then:
         def alignedResultingVersion = "1.0.3"
         dependencyInsightContains(result.output, "test.nebula:a", alignedResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:g", alignedResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", alignedResultingVersion)
 
-        dependencyInsightContains(result.output, "test.nebula:b", '1.0.1')
         dependencyInsightContains(result.output, "test.nebula:c", '1.0.2')
+        dependencyInsightContains(result.output, "test.nebula:g", '1.0.1')
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$alignedResultingVersion")
@@ -1143,16 +1130,16 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'substitution rule includes are honored | core alignment #coreAlignment'() {
+    def 'alignment rule includes are honored | core alignment #coreAlignment'() {
         given:
-        def module = "test.nebula:a:[1.0.0,1.0.3)"
-        def with = "test.nebula:a:1.0.3"
+        def module = "[1.0.1,1.0.3)"
+        def with = "1.0.3"
         rulesJsonFile << """
             {
                 "substitute": [
                     {
-                        "module" : "$module",
-                        "with" : "$with",
+                        "module" : "test.nebula:b:$module",
+                        "with" : "test.nebula:b:$with",
                         "reason" : "$reason",
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
@@ -1163,7 +1150,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                         "group": "(test.nebula|test.nebula.ext)",
                         "reason": "Align test.nebula dependencies",
                         "author": "Example Person <person@example.org>",
-                        "includes": ["(a|g)"],
+                        "includes": ["(a|b)"],
                         "excludes": [],
                         "date": "2016-03-17T20:21:20.368Z"
                     }
@@ -1173,7 +1160,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         buildFile << """
             dependencies {
-                compile 'test.nebula:a:1.0.1'
+                compile 'test.nebula:a:1.0.0'
                 compile 'test.nebula:b:1.0.1'
                 compile 'test.nebula:c:1.0.2'
                 compile 'test.nebula:g:1.0.1'
@@ -1186,10 +1173,10 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         then:
         def alignedResultingVersion = "1.0.3"
         dependencyInsightContains(result.output, "test.nebula:a", alignedResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:g", alignedResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", alignedResultingVersion)
 
-        dependencyInsightContains(result.output, "test.nebula:b", '1.0.1')
         dependencyInsightContains(result.output, "test.nebula:c", '1.0.2')
+        dependencyInsightContains(result.output, "test.nebula:g", '1.0.1')
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$alignedResultingVersion")
@@ -1200,7 +1187,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'recs with core bom support disabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+    def 'recs with core bom support disabled: alignment styles should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
         given:
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
 
@@ -1208,8 +1195,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1217,12 +1204,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false
-        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | false
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false // FIXME: should resolve differently
+        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'recs with core bom support disabled: core alignment should substitute and align from bom version to higher minor-scoped dynamic version | core alignment #coreAlignment'() {
+    def 'recs with core bom support disabled: alignment styles should substitute and align from bom version to higher minor-scoped dynamic version | core alignment #coreAlignment'() {
         given:
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
 
@@ -1230,8 +1217,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1239,12 +1226,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.+"               | "1.0.2"          | false
-        true          | "1.0.2"    | true                                  | "1.+"               | "1.1.0"          | false
+        false         | "1.0.2"    | true                                  | "1.+"               | "1.0.2"          | false // FIXME: should resolve differently
+        true          | "1.0.2"    | true                                  | "1.+"               | "1.0.2"          | false // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'recs with core bom support disabled: core alignment should substitute and align from bom version to higher patch-scoped dynamic version | core alignment #coreAlignment'() {
+    def 'recs with core bom support disabled: alignment styles should substitute and align from bom version to higher patch-scoped dynamic version | core alignment #coreAlignment'() {
         given:
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
 
@@ -1252,8 +1239,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1261,8 +1248,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.0.3"             | "1.0.2"          | false
-        true          | "1.0.2"    | true                                  | "1.0.3"             | "1.0.3"          | false
+        false         | "1.0.2"    | true                                  | "1.0.3"             | "1.0.2"          | false // FIXME: should resolve differently
+        true          | "1.0.2"    | true                                  | "1.0.3"             | "1.0.2"          | false // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
@@ -1274,8 +1261,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1288,7 +1275,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'recs with core bom support enabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+    def 'recs with core bom support enabled: alignment styles should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
         given:
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
 
@@ -1296,8 +1283,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1305,12 +1292,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | true
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | true
         true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | true
     }
 
     @Unroll
-    def 'recs with core bom support enabled: core alignment should substitute and align from bom version to higher minor-scoped dynamic version | core alignment #coreAlignment'() {
+    def 'recs with core bom support enabled: alignment styles should substitute and align from bom version to higher minor-scoped dynamic version | core alignment #coreAlignment'() {
         given:
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
 
@@ -1318,8 +1305,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1327,12 +1314,12 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.+"               | "1.0.2"          | true
-        true          | "1.0.2"    | true                                  | "1.+"               | "1.1.0"          | true
+        false         | "1.0.2"    | true                                  | "1.+"               | "1.1.0"          | true // FIXME: should resolve differently
+        true          | "1.0.2"    | true                                  | "1.+"               | "1.1.0"          | true // keep behavior the same as coreAlignment=false
     }
 
     @Unroll
-    def 'recs with core bom support enabled: core alignment should substitute and align from bom version to higher patch-scoped dynamic version | core alignment #coreAlignment'() {
+    def 'recs with core bom support enabled: alignment styles should substitute and align from bom version to higher patch-scoped dynamic version | core alignment #coreAlignment'() {
         given:
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion)
 
@@ -1340,8 +1327,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1349,7 +1336,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.0.3"             | "1.0.2"          | true
+        false         | "1.0.2"    | true                                  | "1.0.3"             | "1.0.3"          | true
         true          | "1.0.2"    | true                                  | "1.0.3"             | "1.0.3"          | true
     }
 
@@ -1362,8 +1349,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*(tasks(coreAlignment, coreBomSupport)))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1376,7 +1363,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'enforced recs with core bom support disabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+    def 'enforced recs with core bom support disabled: alignment styles should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
         given:
         def usingEnforcedPlatform = true
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion, usingEnforcedPlatform)
@@ -1385,8 +1372,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment, coreBomSupport))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1395,7 +1382,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
         false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false
-        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | false
+        true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | false
     }
 
     @Unroll
@@ -1408,8 +1395,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment, coreBomSupport))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1422,7 +1409,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'enforced recs with core bom support enabled: core alignment should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
+    def 'enforced recs with core bom support enabled: alignment styles should substitute and align from bom version to lower static version | core alignment #coreAlignment'() {
         given:
         def usingEnforcedPlatform = true
         setupForBomAndAlignmentAndSubstitution(bomVersion, substituteToVersion, usingEnforcedPlatform)
@@ -1431,8 +1418,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment, coreBomSupport))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1440,7 +1427,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
 
         where:
         coreAlignment | bomVersion | bomVersionCollidesWithSubsitutionRule | substituteToVersion | resultingVersion | coreBomSupport
-        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.2"          | true
+        false         | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | true
         true          | "1.0.2"    | true                                  | "1.0.1"             | "1.0.1"          | true
     }
 
@@ -1454,8 +1441,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment, coreBomSupport))
 
         then:
-        assert result.output.findAll("test.nebula:a:$resultingVersion").size() >= 1
-        assert result.output.findAll("test.nebula:b:$resultingVersion").size() >= 1
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
@@ -1487,13 +1474,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("test.nebula:a:{require 1.0.1; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-            assert result.output.contains("test.nebula:b:{require 1.0.3; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-
-            assert result.output.contains("rejection of version(s) '1.0.1'")
-            assert result.output.contains("rejection of version(s) '1.0.3'")
-            assert result.output.contains("rejection of version(s) '1.1.0'")
             assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:b:1.0.3' to 'test.nebula:b:1.0.2'")
 
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
@@ -1535,6 +1517,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
             assert result.output.contains("test.nebula:b:{require 1.0.3; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
 
             assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:b:1.0.3' to 'test.nebula:b:1.0.2'")
 
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
@@ -1545,9 +1528,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         true          | "1.0.2"
     }
 
-
     @Unroll
-    def 'multiple substitutions applied: recs with core bom support disabled: core alignment should honor multiple substitutions | core alignment: #coreAlignment'() {
+    def 'multiple substitutions applied: recs with core bom support disabled: alignment styles should honor multiple substitutions | core alignment: #coreAlignment'() {
         given:
         def bomVersion = "1.0.1"
         setupForBomAndAlignmentAndSubstitution(bomVersion, "")
@@ -1564,14 +1546,11 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
+            assert result.output.contains("Recommending version 1.0.1 for dependency test.nebula:a via conflict resolution recommendation")
+            assert result.output.contains("Recommending version 1.0.1 for dependency test.nebula:b via conflict resolution recommendation")
 
-            assert result.output.contains("require version 1.0.2")
-            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
-            assert result.output.contains("rejection of version(s) '1.0.3'")
-            assert result.output.contains("rejection of version(s) '1.1.0'")
-//            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:b:1.0.1' to 'test.nebula:b:1.0.2'")
 
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
@@ -1579,7 +1558,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         coreAlignment | coreBomSupport | resultingVersion
         false         | false          | "1.0.1"
-        true          | false          | "1.0.2"
+        true          | false          | "1.0.1"
     }
 
     @Unroll
@@ -1600,14 +1579,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-
-            assert result.output.contains("require version 1.0.2")
-            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
-            assert result.output.contains("rejection of version(s) '1.0.3'")
-            assert result.output.contains("rejection of version(s) '1.1.0'")
             assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:b:1.0.1' to 'test.nebula:b:1.0.2'")
 
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
@@ -1617,7 +1590,6 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         false         | true           | "1.0.2"
         true          | true           | "1.0.2"
     }
-
 
     @Unroll
     def 'multiple substitutions applied: enforced recs with core bom support disabled: core alignment should honor multiple substitutions | core alignment: #coreAlignment'() {
@@ -1638,14 +1610,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-
-            assert result.output.contains("require version 1.0.2")
-            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
-            assert result.output.contains("rejection of version(s) '1.0.3'")
-            assert result.output.contains("rejection of version(s) '1.1.0'")
-//            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:b:1.0.1' to 'test.nebula:b:1.0.2'")
 
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
@@ -1653,7 +1619,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         coreAlignment | coreBomSupport | resultingVersion
         false         | false          | "1.0.1"
-        true          | false          | "1.0.2"
+        true          | false          | "1.0.1"
     }
 
     @Unroll
@@ -1675,14 +1641,8 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("test.nebula:a:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-            assert result.output.contains("test.nebula:b:{require 1.0.2; reject 1.0.1 & 1.0.3 & 1.1.0} -> 1.0.2")
-
-            assert result.output.contains("require version 1.0.2")
-            assert result.output.contains("rejection of BOM recommended version(s) '1.0.1'")
-            assert result.output.contains("rejection of version(s) '1.0.3'")
-            assert result.output.contains("rejection of version(s) '1.1.0'")
             assert result.output.contains("substitution from 'test.nebula:a:1.0.1' to 'test.nebula:a:1.0.2'")
+            assert result.output.contains("substitution from 'test.nebula:b:1.0.1' to 'test.nebula:b:1.0.2'")
 
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
         }
@@ -1700,20 +1660,42 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                     {
                         "module" : "test.nebula:a:1.0.1",
                         "with" : "test.nebula:a:1.0.2",
-                        "reason" : "(substitution for a)",
+                        "reason" : "1.0.1 is too small",
+                        "author" : "Test user <test@example.com>",
+                        "date" : "2015-10-07T20:21:20.368Z"
+                    },
+                    {
+                        "module" : "test.nebula:b:1.0.1",
+                        "with" : "test.nebula:b:1.0.2",
+                        "reason" : "1.0.1 is too small",
+                        "author" : "Test user <test@example.com>",
+                        "date" : "2015-10-07T20:21:20.368Z"
+                    },
+                    {
+                        "module" : "test.nebula:a:1.1.0",
+                        "with" : "test.nebula:a:1.0.3",
+                        "reason" : "1.1.0 is too large",
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
                     },
                     {
                         "module" : "test.nebula:b:1.1.0",
                         "with" : "test.nebula:b:1.0.3",
-                        "reason" : "(acts as rejection for a)",
+                        "reason" : "1.1.0 is too large",
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
-                    },                    {
+                    },
+                    {
+                        "module" : "test.nebula:a:1.0.3",
+                        "with" : "test.nebula:a:1.0.2",
+                        "reason" : "1.0.3 is also too large",
+                        "author" : "Test user <test@example.com>",
+                        "date" : "2015-10-07T20:21:20.368Z"
+                    },
+                    {
                         "module" : "test.nebula:b:1.0.3",
                         "with" : "test.nebula:b:1.0.2",
-                        "reason" : "(acts as rejection for a)",
+                        "reason" : "1.0.3 is also too large",
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
                     }
@@ -1744,38 +1726,47 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         """.stripIndent()
     }
 
-    private def setupForSimplestSubstitutionAndAlignmentCases(String substituteFromVersion, String substituteToVersion, String dependencyDefinitionVersion) {
-        def module = "test.nebula:b:$substituteFromVersion"
-        def with = "test.nebula:b:$substituteToVersion"
+    private def setupForSimplestSubstitutionAndAlignmentCases(String substituteFromVersion, String substituteToVersion, List<String> definedVersions) {
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:b:$substituteFromVersion".toString(), "test.nebula:b:$substituteToVersion".toString())
+        assert definedVersions.size() == 2
 
-        createAlignAndSubstituteRule(module, with)
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         buildFile << """
             dependencies {
-                compile 'test.nebula:a:$dependencyDefinitionVersion'
-                compile 'test.nebula:b:$dependencyDefinitionVersion'
+                compile 'test.nebula:a:${definedVersions[0]}'
+                compile 'test.nebula:b:${definedVersions[1]}'
             }
             """.stripIndent()
     }
 
-    private def setupForSubstitutionAndAlignmentCasesWithMissingVersions(String subFromVersionAndModule, String subToVersionAndModule, String definedVersion) {
-        def module = "test.nebula:$subFromVersionAndModule"
-        def with = "test.nebula:$subToVersionAndModule"
-        createAlignAndSubstituteRule(module, with)
+    private def setupForSubstitutionAndAlignmentCasesWithMissingVersions(String substituteFromVersion, String substituteToVersion, List<String> definedVersions) {
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:b:$substituteFromVersion".toString(), "test.nebula:b:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:c:$substituteFromVersion".toString(), "test.nebula:c:$substituteToVersion".toString())
+        assert definedVersions.size() == 3
+
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         buildFile << """
             dependencies {
-                compile 'test.nebula:a:$definedVersion'
-                compile 'test.nebula:b:$definedVersion'
-                compile 'test.nebula:c:$definedVersion'
+                compile 'test.nebula:a:${definedVersions[0]}'
+                compile 'test.nebula:b:${definedVersions[1]}'
+                compile 'test.nebula:c:${definedVersions[2]}'
             }
             """.stripIndent()
     }
 
     private def setupForBomAndAlignmentAndSubstitution(String bomVersion, String substituteToVersion, boolean usingEnforcedPlatform = false) {
-        def module = "test.nebula:a:[1.0.2]"
-        def with = "test.nebula:a:$substituteToVersion"
-        createAlignAndSubstituteRule(module, with)
+        def substituteFromVersion = "1.0.2"
+        Map<String, String> modulesAndSubstitutions = new HashMap<>()
+        modulesAndSubstitutions.put("test.nebula:a:$substituteFromVersion".toString(), "test.nebula:a:$substituteToVersion".toString())
+        modulesAndSubstitutions.put("test.nebula:b:$substituteFromVersion".toString(), "test.nebula:b:$substituteToVersion".toString())
+
+        createAlignAndSubstituteRule(modulesAndSubstitutions)
 
         def bomRepo = createBom(["test.nebula:a:$bomVersion", "test.nebula:b:$bomVersion"])
 
@@ -1831,6 +1822,27 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
                         "reason" : "$reason",
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
+                    },
+                    {
+                        "module": "com.google.inject.extensions:guice-assistedinject:[4.2.0,)",
+                        "with": "com.google.inject.extensions:guice-assistedinject:4.1.0",
+                        "reason": "$reason",
+                        "author": "Test user <test@example.com>",
+                        "date": "2015-10-07T20:21:20.368Z"
+                    },
+                    {
+                        "module": "com.google.inject.extensions:guice-grapher:[4.2.0,)",
+                        "with": "com.google.inject.extensions:guice-grapher:4.1.0",
+                        "reason": "$reason",
+                        "author": "Test user <test@example.com>",
+                        "date": "2015-10-07T20:21:20.368Z"
+                    },
+                    {
+                        "module": "com.google.inject.extensions:guice-multibindings:[4.2.0,)",
+                        "with": "com.google.inject.extensions:guice-multibindings:4.1.0",
+                        "reason": "$reason",
+                        "author": "Test user <test@example.com>",
+                        "date": "2015-10-07T20:21:20.368Z"
                     }
                 ]
             }
@@ -1887,6 +1899,34 @@ dependencies {
                         "author" : "Test user <test@example.com>",
                         "date" : "2015-10-07T20:21:20.368Z"
                     }
+                ],
+                "align": [
+                    $alignRuleForTestNebula
+                ]
+            }
+            """.stripIndent()
+    }
+
+    private def createAlignAndSubstituteRule(Map<String, String> modulesAndSubstitutions) {
+        rulesJsonFile << """
+            {
+                "substitute": [
+            """.stripIndent()
+
+        List<String> substitutions = new ArrayList<>()
+        modulesAndSubstitutions.each { module, with ->
+            substitutions.add("""
+                        {
+                            "module" : "$module",
+                            "with" : "$with",
+                            "reason" : "$reason",
+                            "author" : "Test user <test@example.com>",
+                            "date" : "2015-10-07T20:21:20.368Z"
+                        }""".stripIndent())
+        }
+        rulesJsonFile << substitutions.join(',')
+
+        rulesJsonFile << """
                 ],
                 "align": [
                     $alignRuleForTestNebula

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignedPlatformRulesSpec.groovy
@@ -287,7 +287,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to higher static version that is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher static version that is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
         setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
@@ -306,11 +306,11 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
         "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | false         | "1.0.3" // FIXME: should resolve differently
-        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | true          | "1.0.3" // keep behavior the same as coreAlignment=false
+        "static version"      | "1.0.3"               | "1.1.0"             | "higher"           | true          | "1.0.2"
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to higher latest.release dynamic version in narrow definition that is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher latest.release dynamic version in narrow definition that is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
         setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
@@ -329,11 +329,11 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
         "static version"      | "1.0.3"               | "latest.release"    | "higher"           | false         | "1.0.3" // FIXME: should resolve differently
-        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | true          | "1.0.3" // keep behavior the same as coreAlignment=false
+        "static version"      | "1.0.3"               | "latest.release"    | "higher"           | true          | "1.0.2"
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to higher minor-scoped dynamic version that is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to higher minor-scoped dynamic version that is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
         setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
@@ -352,11 +352,11 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
         "static version"      | "1.0.3"               | "1.+"               | "higher"           | false         | "1.0.3" // FIXME: should resolve differently
-        "static version"      | "1.0.3"               | "1.+"               | "higher"           | true          | "1.0.3" // keep behavior the same as coreAlignment=false
+        "static version"      | "1.0.3"               | "1.+"               | "higher"           | true          | "1.0.2"
     }
 
     @Unroll
-    def 'narrowly defined dynamic dependency: alignment styles should substitute and align from static version to conflict-resolved version that is is not substituted-away-from | core alignment: #coreAlignment'() {
+    def 'narrowly defined dynamic dependency: core alignment should substitute and align from static version to conflict-resolved version that is is not substituted-away-from | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = ['1.0.+', '1.0.0']
         setupForSimplestSubstitutionAndAlignmentCases(substituteFromVersion, substituteToVersion, dependencyDefinitionVersions)
@@ -375,7 +375,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         substituteVersionType | substituteFromVersion | substituteToVersion | substituteUpOrDown | coreAlignment | resultingVersion
         "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | false         | "1.0.3" // FIXME: should resolve differently
-        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | true          | "1.0.3" // keep behavior the same as coreAlignment=false
+        "static version"      | "1.0.3"               | "1.0.0"             | "lower"            | true          | "1.0.2"
     }
 
     @Unroll
@@ -519,7 +519,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'missing cases: dynamically defined dependency: alignment styles should fail to align when dynamic dependency definition and substitutions leave no viable versions | core alignment: #coreAlignment'() {
+    def 'missing cases: dynamically defined dependency: core alignment fails to align when dynamic dependency definition and substitutions leave no viable versions | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
         setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
@@ -533,17 +533,18 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$CResultingVersion")
+            def platformVersion = "1.4.0"
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$platformVersion")
         }
 
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
         "range"            | "1.+"          | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | false         | "1.1.0"            | "1.4.0" // FIXME: should resolve differently
-        "range"            | "1.+"          | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | true          | "1.1.0"            | "1.4.0" // keep behavior the same as coreAlignment=false
+        "range"            | "1.+"          | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | true          | "FAILED"           | "FAILED"
     }
 
     @Unroll
-    def 'missing cases: dynamically defined dependency: alignment styles should fail to align when dynamic latest.release dependency definition and substitutions leave no viable versions for some lower aligned versions | core alignment: #coreAlignment'() {
+    def 'missing cases: dynamically defined dependency: core alignment fails to align when dynamic latest.release dependency definition and substitutions leave no viable versions for some lower aligned versions | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
         setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
@@ -552,22 +553,23 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         def result = runTasks(*tasks(coreAlignment))
 
         then:
-        dependencyInsightContains(result.output, "test.nebula:a", ABResultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", ABResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:a", AResultingVersion)
+        dependencyInsightContains(result.output, "test.nebula:b", BResultingVersion)
         dependencyInsightContains(result.output, "test.nebula:c", CResultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$CResultingVersion")
+            def platformVersion = "1.4.0"
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$platformVersion")
         }
 
         where:
-        definedVersionType | definedVersion   | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
-        "range"            | "latest.release" | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | false         | "1.1.0"            | "1.4.0" // FIXME: should resolve differently
-        "range"            | "latest.release" | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | true          | "1.1.0"            | "1.4.0" // keep behavior the same as coreAlignment=false
+        definedVersionType | definedVersion   | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | AResultingVersion | BResultingVersion | CResultingVersion
+        "range"            | "latest.release" | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | false         | "1.1.0"           | "1.1.0"           | "1.4.0" // FIXME: should resolve differently
+        "range"            | "latest.release" | "range"        | "[1.0.0,)"              | "0.5.0"               | "lower"     | true          | "0.5.0"           | "0.6.0"           | "FAILED"
     }
 
     @Unroll
-    def 'missing cases: dynamically defined dependency: alignment styles should fail to align when dependency dynamic definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
+    def 'missing cases: dynamically defined dependency: core alignment fails to align when dependency dynamic definition and substitutions leave no viable versions for some higher aligned dependencies | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
         setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
@@ -587,11 +589,11 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABResultingVersion | CResultingVersion
         "range"            | "1.+"          | "range"        | "[1.0.0,1.2.0)"         | "1.4.0"               | "higher"    | false         | "1.1.0"            | "1.4.0" // FIXME: should resolve differently
-        "range"            | "1.+"          | "range"        | "[1.0.0,1.2.0)"         | "1.4.0"               | "higher"    | true          | "1.1.0"            | "1.4.0" // keep behavior the same as coreAlignment=false
+        "range"            | "1.+"          | "range"        | "[1.0.0,1.2.0)"         | "1.4.0"               | "higher"    | true          | "FAILED"           | "1.4.0"
     }
 
     @Unroll
-    def 'missing cases: narrowly defined dynamic dependency: alignment styles should fail to resolve when narrow dynamic dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
+    def 'missing cases: narrowly defined dynamic dependency: core alignment fails to resolve when narrow dynamic dependency definition and substitutions leave no viable versions for some lower aligned dependencies | core alignment: #coreAlignment'() {
         given:
         List<String> dependencyDefinitionVersions = [definedVersion, '0.6.0', definedVersion]
         setupForSubstitutionAndAlignmentCasesWithMissingVersions(subFromVersionAndModule, subToVersionAndModule, dependencyDefinitionVersions)
@@ -605,13 +607,14 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:c", ABCResultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABCResultingVersion")
+            def platformVersion = "1.0.3"
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$platformVersion")
         }
 
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABCResultingVersion
         "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | false         | "1.0.3" // FIXME: should resolve differently
-        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | true          | "1.0.3" // keep behavior the same as coreAlignment=false
+        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "0.5.0"               | "lower"     | true          | "FAILED"
     }
 
     @Unroll
@@ -629,45 +632,16 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:c", ABCResultingVersion)
 
         if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$ABCResultingVersion")
+            def platformVersion = "1.0.3"
+            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$platformVersion")
         }
 
         where:
         definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | ABCResultingVersion
         "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | false         | "1.0.3" // FIXME: should resolve differently
-        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | true          | "1.0.3" // keep behavior the same as coreAlignment=false
+        "narrow range"     | "1.0.+"        | "range"        | "[1.0.0,1.1.0)"         | "1.4.0"               | "higher"    | true          | "FAILED"
     }
 
-    @Unroll
-    def 'should not apply substitution to modules not listed in substitution rule | core alignment: #coreAlignment'() {
-        given:
-        def module = "test.nebula:$subFromVersionAndModule"
-        def with = "test.nebula:$subToVersionAndModule"
-        createAlignAndSubstituteRule([(module.toString()): with])
-
-        buildFile << """
-            dependencies {
-                compile 'test.nebula:a:$definedVersion'
-                compile 'test.nebula:b:$definedVersion'
-            }
-            """.stripIndent()
-
-        when:
-        def result = runTasks(*tasks(coreAlignment))
-
-        then:
-        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
-        dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
-
-        if (coreAlignment) {
-            assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext")
-        }
-
-        where:
-        definedVersionType | definedVersion | subVersionType | subFromVersionAndModule | subToVersionAndModule | subUpOrDown | coreAlignment | resultingVersion
-        "range"            | "1.+"          | "range"        | "a:[1.0.0,1.2.0)"       | "a:0.5.0"             | "lower"     | false         | "1.1.0" // FIXME: A & B could resolve differently
-        "range"            | "1.+"          | "range"        | "a:[1.0.0,1.2.0)"       | "a:0.5.0"             | "lower"     | true          | "1.1.0" // keep behavior the same as coreAlignment=false
-    }
 
     @Unroll
     def 'substitute static version for other dependency latest.release and align direct deps | core alignment #coreAlignment'() {
@@ -1006,14 +980,16 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         setupForGuiceAndLibraryDependency(definedVersion)
 
         when:
-        def result = runTasks(*tasks(coreAlignment, false, 'com.google.inject'))
+        def result = runTasks('dependencies', *tasks(coreAlignment, false, 'com.google.inject'))
 
         then:
         dependencyInsightContains(result.output, "com.google.inject.extensions:guice-assistedinject", resultingVersion)
         dependencyInsightContains(result.output, "com.google.inject.extensions:guice-grapher", resultingVersion)
         dependencyInsightContains(result.output, "com.google.inject.extensions:guice-multibindings", resultingVersion)
 
-        if (!guiceIsSubstituted) {
+        if (guiceIsSubstituted) {
+            dependencyInsightContains(result.output, "com.google.inject:guice", resultingVersion)
+        } else {
             // since this test uses an external dependency that keeps incrementing, let's check that it just doesn't get the same result
             def content = "com.google.inject:guice:.*$resultingVersion\n"
             assert result.output.findAll(content).size() == 0
@@ -1031,7 +1007,7 @@ class AlignedPlatformRulesSpec extends IntegrationTestKitSpec {
         where:
         coreAlignment | definedVersion | resultingVersion | guiceIsSubstituted
         false         | '4.+'          | '4.1.0'          | false // FIXME: should resolve differently
-        true          | '4.+'          | '4.1.0'          | false // keep behavior the same as coreAlignment=false
+        true          | '4.+'          | '4.1.0'          | true
     }
 
     @Unroll
@@ -1859,13 +1835,13 @@ repositories {
 dependencies {
     //at the time of writing resolves to 4.2.2
     compile "com.google.inject:guice:$definedVersion"
-    compile "sample:module:1.0"
+    compile "test.nebula:a:1.0"
 }
 """
 
         MavenRepo repo = new MavenRepo()
         repo.root = new File(projectDir, 'repo')
-        Pom pom = new Pom('sample', 'module', '1.0', ArtifactType.POM)
+        Pom pom = new Pom('test.nebula', 'a', '1.0', ArtifactType.POM)
         pom.addDependency('com.google.inject.extensions', 'guice-grapher', '4.1.0')
         repo.poms.add(pom)
         repo.generate()

--- a/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
@@ -87,13 +87,6 @@ class ResolutionRulesPlugin : Plugin<Project> {
                             rule.apply(project, config, config.resolutionStrategy, extension, reasons)
                         }
 
-                        if (isCoreAlignmentEnabled()) {
-                            val alignedPlatformRules = generateAlignedPlatformRules(ruleSet.align, ruleSet.substitute)
-                            alignedPlatformRules.forEach { rule ->
-                                rule.apply(project, config, config.resolutionStrategy, extension, reasons)
-                            }
-                        }
-
                         ruleSet.dependencyRulesPartTwo().forEach { rule ->
                             rule.apply(project, config, config.resolutionStrategy, extension, reasons)
                         }
@@ -112,28 +105,6 @@ class ResolutionRulesPlugin : Plugin<Project> {
                 }
             }
         }
-    }
-
-    private fun generateAlignedPlatformRules(alignRules: List<AlignRule>, substituteRules: List<SubstituteRule>): List<AlignedPlatformRule> {
-        val alignToSubstitutes: MutableMap<AlignRule, MutableList<SubstituteRule>> = mutableMapOf()
-        val forAlignedPlatform: MutableList<AlignedPlatformRule> = mutableListOf()
-
-        alignRules.forEach { alignRule ->
-            substituteRules.forEach { substituteRule ->
-                val substitution = ModuleVersionIdentifier.valueOf(substituteRule.module)
-                if (alignRule.ruleMatches(substitution.organization, substitution.name)) {
-                    if (!alignToSubstitutes.containsKey(alignRule)) {
-                        alignToSubstitutes[alignRule] = mutableListOf()
-                    }
-                    alignToSubstitutes[alignRule]!!.add(substituteRule)
-                }
-            }
-        }
-
-        alignToSubstitutes.forEach { (alignRule, listOfSubstituteRules) ->
-            forAlignedPlatform.add(AlignedPlatformRule(alignRule, listOfSubstituteRules))
-        }
-        return forAlignedPlatform
     }
 
     private fun rulesFromConfiguration(project: Project, extension: NebulaResolutionRulesExtension): RuleSet {

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -18,7 +18,6 @@ package nebula.plugin.resolutionrules
 
 import com.netflix.nebula.interop.VersionWithSelector
 import com.netflix.nebula.interop.action
-import netflix.nebula.dependency.recommender.DependencyRecommendationsPlugin
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.*
@@ -81,88 +80,6 @@ data class RuleSet(
     }
 }
 
-class AlignedPlatformRule(alignRule: AlignRule, substituteRules: MutableList<SubstituteRule>) : CanRejectDependency, Serializable {
-    var substituteRules: List<SubstituteRule> = substituteRules
-    var alignRule: AlignRule = alignRule
-
-    fun apply(project: Project, configuration: Configuration, resolutionStrategy: ResolutionStrategy, extension: NebulaResolutionRulesExtension, reasons: MutableSet<String>) {
-        substituteRules.forEach {
-            val substitution = resolutionStrategy.dependencySubstitution
-            val selector = substitution.module(it.module)
-            val substitutedModule = selector as? ModuleComponentSelector
-
-            val withModuleId = ModuleVersionIdentifier.valueOf(it.with)
-            if (!withModuleId.hasVersion()) {
-                throw SubstituteRuleMissingVersionException(withModuleId, it, reasons)
-            }
-            val withSelector = substitution.module(withModuleId.toString()) as ModuleComponentSelector
-
-            if (substitutedModule != null) {
-                firstLevelDependenciesRejectTheSubstitutedVersions(project, configuration, substitutedModule, withSelector)
-                transitiveDependenciesRejectTheSubstitutedVersions(project, substitutedModule, withSelector)
-                it.applyForAlignedGroup(project, configuration, configuration.resolutionStrategy, extension, reasons, alignRule)
-            }
-        }
-    }
-
-    private fun transitiveDependenciesRejectTheSubstitutedVersions(project: Project, substitutedModule: ModuleComponentSelector, withSelector: ModuleComponentSelector) {
-        project.dependencies.components.all(TransitiveDependenciesSubstitutionMetadataRule::class.java) {
-            it.params(alignRule, substitutedModule.group, substitutedModule.module, substitutedModule.version, withSelector.version)
-        }
-    }
-
-    private fun firstLevelDependenciesRejectTheSubstitutedVersions(project: Project, configuration: Configuration, substitutedModule: ModuleComponentSelector,
-                                                                   withSelector: ModuleComponentSelector) {
-        configuration.incoming.beforeResolve { resolvableDependencies ->
-            resolvableDependencies.dependencies.forEach { dep ->
-                if (dep is ExternalModuleDependency) {
-                    if (alignRule.ruleMatches(dep.group ?: "", dep.name)) {
-                        val usingDependencyRecommendation = dep.version.isNullOrEmpty()
-
-                        if (usingDependencyRecommendation) {
-                            applyConstraintsToDependencyIfRecommendedVersionMatches(project, dep, substitutedModule, withSelector, configuration)
-                        } else {
-                            applyConstraintsToDependency(dep, substitutedModule, configuration)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun applyConstraintsToDependencyIfRecommendedVersionMatches(project: Project, dep: ExternalModuleDependency, substitutedModule: ModuleComponentSelector,
-                                                                        withSelector: ModuleComponentSelector, configuration: Configuration) {
-        val recommendedVersion = DependencyRecommendationsPlugin().getRecommendedVersionRecursive(project, dep)
-        if (recommendedVersion != null) {
-            val substitutedModuleVersionWithSelector = VersionWithSelector(substitutedModule.version)
-
-            if (substitutedModuleVersionWithSelector.asSelector().accept(recommendedVersion)) {
-                applyConstraintsToDependencyWithRecommendation(dep, withSelector, configuration, substitutedModule)
-            }
-        }
-    }
-
-    private fun applyConstraintsToDependency(dep: ExternalModuleDependency, substitutedModule: ModuleComponentSelector, configuration: Configuration) {
-        val reason = "rejection of version(s) '${substitutedModule.version}' for incoming dependency '${dep.group}:${dep.name}' " +
-                "before resolution, " +
-                "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}'"
-        rejectVersion(dep, substitutedModule.version, reason)
-    }
-
-    private fun applyConstraintsToDependencyWithRecommendation(dep: ExternalModuleDependency, withSelector: ModuleComponentSelector,
-                                                               configuration: Configuration, substitutedModule: ModuleComponentSelector) {
-        val requiredVersion = withSelector.version
-        if (!alreadyRequiredThisVersion(dep.versionConstraint, requiredVersion)) {
-
-            val reason = "require version ${withSelector.version} and rejection of BOM recommended version(s) '${substitutedModule.version}' " +
-                    "for incoming dependency '${dep.group}:${dep.name}' " +
-                    "based on alignment group '${substitutedModule.group}' in rule set '${alignRule.ruleSet}' " +
-                    "because recommended version matched a substitution rule version."
-            rejectVersion(dep, substitutedModule.version, reason, requiredVersion)
-        }
-    }
-}
-
 fun RuleSet.withName(ruleSetName: String): RuleSet {
     name = ruleSetName
     listOf(replace, substitute, reject, deny, exclude, align).flatten().forEach { it.ruleSet = ruleSetName }
@@ -193,7 +110,7 @@ data class ReplaceRule(override val module: String, val with: String, override v
 }
 
 data class SubstituteRule(val module: String, val with: String, override var ruleSet: String?,
-                          override val reason: String, override val author: String, override val date: String) : BasicRule, Serializable {
+                          override val reason: String, override val author: String, override val date: String) : BasicRule, CanRejectDependency, Serializable {
     override fun apply(project: Project, configuration: Configuration, resolutionStrategy: ResolutionStrategy, extension: NebulaResolutionRulesExtension, reasons: MutableSet<String>) {
         val substitution = resolutionStrategy.dependencySubstitution
         val substitutedModule = substitution.module(module)
@@ -210,6 +127,10 @@ data class SubstituteRule(val module: String, val with: String, override var rul
                     if (requestedSelector.group == substitutedModule.group && requestedSelector.module == substitutedModule.module) {
                         val versionSelector = VersionWithSelector(substitutedModule.version).asSelector()
                         if (versionSelector.accept(requestedSelector.version)) {
+                            if (ResolutionRulesPlugin.isCoreAlignmentEnabled()) {
+                                requireVersionFromSubstitutionRule(configuration, substitutedModule.group, substitutedModule.module, withSelector.version)
+                            }
+
                             val message = "substitution from '$substitutedModule' to '$withSelector' because $reason \n" +
                                     "\twith reasons: ${reasons.joinToString()}"
                             // Note on `useTarget`:
@@ -218,6 +139,11 @@ data class SubstituteRule(val module: String, val with: String, override var rul
                             useTarget(withSelector, message)
                         }
                     }
+                }
+                if (ResolutionRulesPlugin.isCoreAlignmentEnabled()) {
+                    // Presently only calling this when substitution is triggered, to align with Nebula implementation
+                    firstLevelDependenciesRejectTheSubstitutedVersions(configuration, substitutedModule, withSelector)
+                    transitiveDependenciesRejectTheSubstitutedVersions(project, substitutedModule, withSelector)
                 }
             })
         } else {
@@ -229,6 +155,10 @@ data class SubstituteRule(val module: String, val with: String, override var rul
                 val selectorGroupAndArtifact = "${selectorNameSections[0]}:${selectorNameSections[1]}"
                 message = "substitution from '$selectorGroupAndArtifact' to '$withSelector' because $reason \n" +
                         "\twith reasons: ${reasons.joinToString()}"
+
+                if (ResolutionRulesPlugin.isCoreAlignmentEnabled()) {
+                    requireVersionFromSubstitutionRule(configuration, selectorNameSections[0], selectorNameSections[1], withSelector.version)
+                }
             }
 
             resolutionStrategy.dependencySubstitution {
@@ -239,51 +169,57 @@ data class SubstituteRule(val module: String, val with: String, override var rul
         }
     }
 
-    fun applyForAlignedGroup(project: Project, configuration: Configuration, resolutionStrategy: ResolutionStrategy,
-                             extension: NebulaResolutionRulesExtension, reasons: MutableSet<String>, alignRule: AlignRule) {
-        val substitution = resolutionStrategy.dependencySubstitution
-        val selector = substitution.module(module)
-        val withModuleId = ModuleVersionIdentifier.valueOf(with)
-        if (!withModuleId.hasVersion()) {
-            throw SubstituteRuleMissingVersionException(withModuleId, this, reasons)
-        }
-        val withSelector = substitution.module(withModuleId.toString()) as ModuleComponentSelector
-
-        if (selector is ModuleComponentSelector) {
-            resolutionStrategy.dependencySubstitution.all(action {
-                if (requested is ModuleComponentSelector) {
-                    val requestedSelector = requested as ModuleComponentSelector
-                    val requestedWithSubstitutedVersionFromAlignedModule = ModuleVersionIdentifier.valueOf("${requestedSelector.group}:${requestedSelector.module}:${withSelector.version}")
-
-                    val matches = alignRule.ruleMatches(requestedSelector.group ?: "", requestedSelector.module)
-                    val notTheOriginatingDependency = requestedSelector.module != selector.module
-                    if (matches && notTheOriginatingDependency) {
-                        val versionSelector = VersionWithSelector(selector.version).asSelector()
-                        if (versionSelector.accept(requestedSelector.version)) {
-                            val message = "substitution from aligned dependency '$selector' to '$withSelector' because '$reason'\n" +
-                                    "\twith reasons: ${reasons.joinToString()}"
-                            val updatedRequestedModuleComponentSelector = substitution.module(requestedWithSubstitutedVersionFromAlignedModule.toString()) as ModuleComponentSelector
-                            useTarget(updatedRequestedModuleComponentSelector, message)
+    private fun requireVersionFromSubstitutionRule(configuration: Configuration, group: String, name: String, versionToRequire: String) {
+        configuration.incoming.beforeResolve { resolvableDependencies ->
+            resolvableDependencies.dependencies
+                    .filter { it is ExternalModuleDependency }
+                    .filter { it.group == group }
+                    .filter { it.name == name }
+                    .forEach { dep ->
+                        (dep as ExternalModuleDependency).version {
+                            it.require(versionToRequire)
                         }
                     }
+        }
+    }
+
+    private fun firstLevelDependenciesRejectTheSubstitutedVersions(configuration: Configuration, substitutedModule: ModuleComponentSelector,
+                                                                   withSelector: ModuleComponentSelector) {
+        configuration.incoming.beforeResolve { resolvableDependencies ->
+            resolvableDependencies.dependencies.forEach { dep ->
+                if (dep is ExternalModuleDependency) {
+                    if (dep.group == substitutedModule.group && dep.name == substitutedModule.module) {
+                        // TODO behavior change: use something like `if (alignRule.ruleMatches(dep.group ?: "", dep.name)) {`
+                        // TODO behavior change: check if dependency recommendation should be used:
+                        applyConstraintsToDependency(dep, substitutedModule, configuration)
+                    }
                 }
-            })
-        } else {
-            // do nothing if there is no version
+            }
+        }
+    }
+
+    private fun applyConstraintsToDependency(dep: ExternalModuleDependency, substitutedModule: ModuleComponentSelector, configuration: Configuration) {
+        val reason = "rejection of version(s) '${substitutedModule.version}' for incoming dependency '${dep.group}:${dep.name}' " +
+                "before resolution, " +
+                "based on substitution rule for '${substitutedModule.group}:${substitutedModule.module}'"
+        rejectVersion(dep, substitutedModule.version, reason)
+    }
+
+    private fun transitiveDependenciesRejectTheSubstitutedVersions(project: Project, substitutedModule: ModuleComponentSelector, withSelector: ModuleComponentSelector) {
+        project.dependencies.components.all(TransitiveDependenciesSubstitutionMetadataRule::class.java) {
+            it.params(substitutedModule.group, substitutedModule.module, substitutedModule.version, withSelector.version)
         }
     }
 }
 
 class TransitiveDependenciesSubstitutionMetadataRule : CanRejectDependency, ComponentMetadataRule, Serializable {
-    val alignRule: AlignRule
     val substitutionGroup: String
     val substitutionModuleName: String
     val substitutionVersion: String
     val withSelectorVersion: String
 
     @Inject
-    constructor(alignRule: AlignRule, substitutionGroup: String, substitutionModuleName: String, substitutionVersion: String, withSelectorVersion: String) {
-        this.alignRule = alignRule
+    constructor(substitutionGroup: String, substitutionModuleName: String, substitutionVersion: String, withSelectorVersion: String) {
         this.substitutionGroup = substitutionGroup
         this.substitutionModuleName = substitutionModuleName
         this.substitutionVersion = substitutionVersion
@@ -299,9 +235,9 @@ class TransitiveDependenciesSubstitutionMetadataRule : CanRejectDependency, Comp
         details.allVariants {
             it.withDependencies { deps ->
                 deps.forEach { dep ->
-                    if (alignRule.ruleMatches(dep.group ?: "", dep.name)) {
+                    if (dep.group == substitutionGroup && dep.name == substitutionModuleName) { // TODO: could use something like `alignRule.ruleMatches(dep.group ?: "", dep.name)`
                         val reason = "rejection of transitive dependency ${dep.group}:${dep.name} version(s) " +
-                                "'$substitutionVersion' from aligned dependency '$substitutionGroup:$substitutionModuleName'"
+                                "'$substitutionVersion' from dependency '$substitutionGroup:$substitutionModuleName'"
                         rejectVersion(dep, substitutionVersion, reason)
                     }
                 }

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -140,12 +140,14 @@ data class SubstituteRule(val module: String, val with: String, override var rul
                         }
                     }
                 }
-                if (ResolutionRulesPlugin.isCoreAlignmentEnabled()) {
-                    // Presently only calling this when substitution is triggered, to align with Nebula implementation
-                    firstLevelDependenciesRejectTheSubstitutedVersions(configuration, substitutedModule, withSelector)
-                    transitiveDependenciesRejectTheSubstitutedVersions(project, substitutedModule, withSelector)
-                }
             })
+            if (ResolutionRulesPlugin.isCoreAlignmentEnabled()) {
+                // Call this even when substitution doesn't match (such as requested version 1.+).
+                // Dependencies that are pulled in both directly (but do not match the substitution rule) and transitively
+                // will have rejections added to them post-resolution that can cause a failure to resolve without this
+                firstLevelDependenciesRejectTheSubstitutedVersions(configuration, substitutedModule, withSelector)
+                transitiveDependenciesRejectTheSubstitutedVersions(project, substitutedModule, withSelector)
+            }
         } else {
             var message = "substitution to '$withSelector' because $reason \n" +
                     "\twith reasons: ${reasons.joinToString()}"


### PR DESCRIPTION
Core alignment will add rejections in the substitution rule rather than in an aligned platform rule, and will add relevant rejections to all direct dependencies. This second part is done to ensure that rejections are not only added after resolution of direct dependencies, if the dependency is also brought in transitively.