### PR TITLE
Ignore ktlint configurations

### DIFF
--- a/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
@@ -47,12 +47,12 @@ class ResolutionRulesPlugin : Plugin<Project> {
     private lateinit var mapper: ObjectMapper
     private var reasons: MutableSet<String> = mutableSetOf()
     private val ignoredConfigurationPrefixes = listOf(RESOLUTION_RULES_CONFIG_NAME, SPRING_VERSION_MANAGEMENT_CONFIG_NAME,
-            NEBULA_RECOMMENDER_BOM_CONFIG_NAME, SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX, KTLINT_CONFIG_NAME)
+            NEBULA_RECOMMENDER_BOM_CONFIG_NAME, SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX, KTLINT_CONFIGURATION_PREFIX)
 
     companion object Constants {
         fun isCoreAlignmentEnabled() = java.lang.Boolean.getBoolean("nebula.features.coreAlignmentSupport")
         const val SPRING_VERSION_MANAGEMENT_CONFIG_NAME = "versionManagement"
-        const val KTLINT_CONFIG_NAME = "ktlint"
+        const val KTLINT_CONFIGURATION_PREFIX = "ktlint"
         const val SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX = "incrementalScalaAnalysis"
         const val JSON_EXT = ".json"
         const val JAR_EXT = ".jar"

--- a/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
@@ -47,11 +47,12 @@ class ResolutionRulesPlugin : Plugin<Project> {
     private lateinit var mapper: ObjectMapper
     private var reasons: MutableSet<String> = mutableSetOf()
     private val ignoredConfigurationPrefixes = listOf(RESOLUTION_RULES_CONFIG_NAME, SPRING_VERSION_MANAGEMENT_CONFIG_NAME,
-            NEBULA_RECOMMENDER_BOM_CONFIG_NAME, SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX)
+            NEBULA_RECOMMENDER_BOM_CONFIG_NAME, SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX, KTLINT_CONFIG_NAME)
 
     companion object Constants {
         fun isCoreAlignmentEnabled() = java.lang.Boolean.getBoolean("nebula.features.coreAlignmentSupport")
         const val SPRING_VERSION_MANAGEMENT_CONFIG_NAME = "versionManagement"
+        const val KTLINT_CONFIG_NAME = "ktlint"
         const val SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX = "incrementalScalaAnalysis"
         const val JSON_EXT = ".json"
         const val JAR_EXT = ".jar"


### PR DESCRIPTION
This should fix the following issue:

```
 Where:
Build file '/Users/rperezalcolea/Projects/github/rpalcolea/test-nebula-release-ktlint/build.gradle' line: 33

* What went wrong:
A problem occurred evaluating root project 'test-nebula-release-ktlint'.
> Failed to apply plugin [id 'org.jlleitschuh.gradle.ktlint']
   > Could not create task ':ktlintMainSourceSetCheck'.
      > Project#afterEvaluate(Action) on root project 'test-nebula-release-ktlint' cannot be executed in the current context.

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating root project 'test-nebula-release-ktlint'.

used by: org.gradle.api.internal.AbstractMutationGuard$IllegalMutationException: Project#afterEvaluate(Action) on root project 'test-nebula-release-ktlint' cannot be executed in the current context.
        at org.gradle.api.internal.AbstractMutationGuard.createIllegalStateException(AbstractMutationGuard.java:39)
        at org.gradle.api.internal.AbstractMutationGuard.assertMutationAllowed(AbstractMutationGuard.java:34)
        at org.gradle.api.internal.project.DefaultProject.assertMutatingMethodAllowed(DefaultProject.java:1430)
        at org.gradle.api.internal.project.DefaultProject.afterEvaluate(DefaultProject.java:993)
        at nebula.plugin.resolutionrules.ResolutionRulesPlugin$apply$1.execute(plugin.kt:201)
        at nebula.plugin.resolutionrules.ResolutionRulesPlugin$apply$1.execute(plugin.kt:36)
        at org.gradle.api.internal.DefaultCollectionCallbackActionDecorator$BuildOperationEmittingAction$1$1.run(DefaultCollectionCallbackActionDecorator.java:100)
        at org.gradle.configuration.internal.DefaultUserCodeApplicationContext.reapply(DefaultUserCodeApplicationContext.java:60)
        at org.gradle.api.internal.DefaultCollectionCallbackActionDecorator$BuildOperationEmittingAction$1.run(DefaultCollectionCallbackActionDecorator.java:97)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
```