### PR TITLE
SubstituteRule: introduce memoize for version selectors

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/SubstituteRulesWithMemoizeSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/SubstituteRulesWithMemoizeSpec.groovy
@@ -1,0 +1,73 @@
+package nebula.plugin.resolutionrules
+
+import nebula.test.IntegrationSpec
+import org.codehaus.groovy.runtime.StackTraceUtils
+
+class SubstituteRulesWithMemoizeSpec extends IntegrationSpec {
+    File rulesJsonFile
+    File rulesJsonFileSecondary
+
+    def setup() {
+        rulesJsonFile = new File(projectDir, "${moduleName}.json")
+        rulesJsonFileSecondary = new File(projectDir, "${moduleName}-secondary.json")
+
+        buildFile << """
+                     apply plugin: 'java'
+                     apply plugin: 'nebula.resolution-rules'
+
+                     repositories {
+                         jcenter()
+                     }
+
+                     dependencies {
+                         resolutionRules files("$rulesJsonFile")
+                         resolutionRules files("$rulesJsonFileSecondary")
+                     }
+                     """.stripIndent()
+
+        rulesJsonFile << """
+                        {
+                            "substitute": [
+                                {
+                                    "module": "com.google.guava:guava:19.0-rc2",
+                                    "with": "com.google.guava:guava:19.0-rc1",
+                                    "reason" : "Guava 19.0-rc2 is not permitted, use previous release",
+                                    "author" : "Danny Thomas <dmthomas@gmail.com>",
+                                    "date" : "2015-10-07T20:21:20.368Z"
+                                }
+                            ]
+                        }
+                        """.stripIndent()
+
+        rulesJsonFileSecondary << """
+                        {
+                            "substitute": [
+                                {
+                                    "module": "com.google.guava:guava-testlib:19.0-rc2",
+                                    "with": "com.google.guava:guava-testlib:19.0-rc1",
+                                    "reason" : "guava-testlib 19.0-rc2 is not permitted, use previous release",
+                                    "author" : "Danny Thomas <dmthomas@gmail.com>",
+                                    "date" : "2015-10-07T20:21:20.368Z"
+                                }
+                            ]
+                        }
+                        """.stripIndent()
+    }
+
+    def 'substitute dependency with version'() {
+        given:
+        buildFile << """
+                     dependencies {
+                        implementation'com.google.guava:guava:19.0-rc2'
+                        implementation'com.google.guava:guava-testlib:19.0-rc2'
+                     }
+                     """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        result.standardOutput.contains('com.google.guava:guava:19.0-rc2 -> 19.0-rc1')
+        result.standardOutput.contains('com.google.guava:guava-testlib:19.0-rc2 -> 19.0-rc1')
+    }
+}


### PR DESCRIPTION
I don't think Kotlin has a memoize support out of the box and also didn't want to introduce a cache library so created my version of it using a map.

Here is how it looks like 
![Screen Shot 2020-06-17 at 7 13 05 PM](https://user-images.githubusercontent.com/1625920/84970037-c00c3b00-b0ce-11ea-881f-08a1214bb39b.png)
![Screen Shot 2020-06-17 at 7 13 11 PM](https://user-images.githubusercontent.com/1625920/84970038-c0a4d180-b0ce-11ea-8a4d-cf99a55f0f5c.png)

If you look at `SubstituteRulesWithMemoizeSpec`, we have two rule sets which substitute dependencies with version `19.0-rc2`

Looking at the screenshots, if you look at the `versionSelector` (`ExactVersionSelector`), it has uses the same object across rules.

The old approach would look like this

![Screen Shot 2020-06-17 at 7 17 07 PM](https://user-images.githubusercontent.com/1625920/84970267-2beea380-b0cf-11ea-8cb5-2b0f063ec58f.png)

![Screen Shot 2020-06-17 at 7 17 12 PM](https://user-images.githubusercontent.com/1625920/84970270-2d1fd080-b0cf-11ea-8381-2b3e4d2fb38a.png)

