### PR TITLE
Resolution rules should not be applied after the project is evaluated to honor dependency locks

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignRulesWithDependencyLockSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignRulesWithDependencyLockSpec.groovy
@@ -1,0 +1,102 @@
+package nebula.plugin.resolutionrules
+
+import nebula.test.IntegrationTestKitSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import spock.lang.Unroll
+
+class AlignRulesWithDependencyLockSpec extends IntegrationTestKitSpec {
+    File rulesJsonFile
+
+    def setup() {
+        rulesJsonFile = new File(projectDir, "rules.json")
+        debug = true
+    }
+
+    @Unroll
+    def 'dependency locks are honored over alignment rules'() {
+        def lock = new File(projectDir, 'dependencies.lock')
+        lock << """\
+                {
+                    "compileClasspath": {
+                        "test.nebula:a": {
+                            "locked": "1.41.5"
+                        },
+                        "test.nebula:b": {
+                            "locked": "1.42.2"
+                        }
+                    },
+                    "runtimeClasspath": {
+                        "test.nebula:a": {
+                            "locked": "1.41.5"
+                        },
+                        "test.nebula:b": {
+                            "locked": "1.42.2"
+                        }
+                    }
+                }
+        """
+        rulesJsonFile << alignTestNebulaRule()
+        buildFile << """\
+            buildscript {
+                repositories { jcenter() }
+                dependencies {
+                    classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:9.0.0'
+                }
+            }
+
+            plugins {
+                id 'nebula.resolution-rules'
+                id 'java'
+            }
+            apply plugin: 'nebula.dependency-lock'
+
+            repositories {
+                maven { url '${getMavenRepo().toURI().toURL()}' }              
+            }
+
+            dependencies {
+                resolutionRules files('$rulesJsonFile')
+                implementation 'test.nebula:a:1.41.5'
+                implementation 'test.nebula:b:1.42.2'
+            }
+        """.stripIndent()
+
+        when:
+        def compileClasspathResult = runTasks('dependencyInsight', '--dependency', 'test.nebula:a', '--configuration', 'compileClasspath', '--refresh-dependencies')
+
+        then:
+        // final results where locks win over new alignment rules
+        compileClasspathResult.output.contains 'Selected by rule : aligned to 1.42.2 by rule rules aligning group \'test.nebula\''
+        compileClasspathResult.output.contains 'Selected by rule : test.nebula:a locked to 1.41.5'
+        compileClasspathResult.output.contains 'test.nebula:a:1.41.5\n'
+    }
+
+    private static String alignTestNebulaRule() {
+        """
+       {
+                "deny": [], "reject": [], "substitute": [], "replace": [],
+                "align": [
+                    {
+                        "name": "testNebula",
+                        "group": "test.nebula",
+                        "reason": "Align test.nebula dependencies",
+                        "author": "Example Person <person@example.org>",
+                        "date": "2016-03-17T20:21:20.368Z"
+                    }
+                ]
+            }
+        """.stripIndent()
+    }
+
+    private File getMavenRepo() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:a:1.41.5')
+                .addModule('test.nebula:a:1.42.2')
+                .addModule('test.nebula:b:1.41.5')
+                .addModule('test.nebula:b:1.42.2')
+                .build()
+        def mavenrepo = new GradleDependencyGenerator(graph, "$projectDir/testrepogen")
+        mavenrepo.generateTestMavenRepo()
+    }
+}


### PR DESCRIPTION
Found that https://github.com/nebula-plugins/gradle-resolution-rules-plugin/commit/e6ad9277c9a2e1c80f98fae1a098a2f51c6b11dc introduced ability to ignore configurations at the cost of moving everything to `afterEvaluate`. 

Unfortunately, we didn't catch this in our tests. The test that I just added should make sure that both rule and lock are in the reasons for dependency insight + use the locked version

This change is to rollback the `afterEvaluate` and also make sure that the rules are read properly as we added the read to `afterEvaluate` because of the extension usage

One important thing that I found is that the lock is not honored by core alignment flag but that's something we can tackle later.

```
|                       
|                      > Task :dependencyInsight
|                      test.nebula:a:1.42.2
|                         variant "apiElements" [
|                            org.gradle.category            = library
|                            org.gradle.dependency.bundling = external
|                            org.gradle.jvm.version         = 8
|                            org.gradle.libraryelements     = jar (compatible with: classes)
|                            org.gradle.usage               = java-api
|                            org.gradle.status              = release (not requested)
|                         ]
|                         Selection reasons:
|                            - By constraint : belongs to platform aligned-platform:rules-0-for-test.nebula:1.42.2
|                            - Selected by rule : test.nebula:a locked to 1.41.5
|                              	with reasons: nebula.dependency-lock locked with: dependencies.lock
|                            - By conflict resolution : between versions 1.42.2 and 1.41.5
|                       
|                      test.nebula:a:1.41.5 -> 1.42.2
|                      \--- compileClasspath
|                       
```