### PR TITLE
Core Gradle alignment can be enabled from an extension

### DIFF
--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -20,7 +20,11 @@ import com.netflix.nebula.interop.VersionWithSelector
 import com.netflix.nebula.interop.action
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.artifacts.*
+import org.gradle.api.artifacts.ComponentModuleMetadataDetails
+import org.gradle.api.artifacts.ComponentSelection
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.logging.Logger
@@ -54,14 +58,14 @@ data class RuleSet(
     fun dependencyRulesPartOne() =
             listOf(replace, substitute, reject, deny, exclude).flatten()
 
-    fun dependencyRulesPartTwo() =
-            if (ResolutionRulesPlugin.isCoreAlignmentEnabled())
+    fun dependencyRulesPartTwo(coreAlignmentEnabled: Boolean) =
+            if (coreAlignmentEnabled)
                 listOf(align).flatten()
             else
                 emptyList()
 
-    fun resolveRules() =
-            if (ResolutionRulesPlugin.isCoreAlignmentEnabled())
+    fun resolveRules(coreAlignmentEnabled: Boolean) =
+            if (coreAlignmentEnabled)
                 emptyList()
             else
                 listOf(AlignRules(align))


### PR DESCRIPTION
The value from the extension will be used if there is no passed in property. The extension value defaults to false

This enables setting the value via an extension without using a property, and allows us to update the value until `project.onExecute` or `config.onResolve` take place