### PR TITLE
Gradle 6.7-rc-1 and alignment updates

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAndSubstituteRulesSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAndSubstituteRulesSpec.groovy
@@ -1006,12 +1006,10 @@ class AlignAndSubstituteRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
         dependencyInsightContains(result.output, "test.nebula:c", resultingVersion)
 
-        if (coreAlignment) {
-            dependencyInsightContains(result.output, "test.nebula:a", '0.5.0')
+        dependencyInsightContains(result.output, "test.nebula:a", resultingVersion) // alignment wins over the details.useVersion via `By conflict resolution : between versions 1.0.0 and 0.5.0`
 
+        if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
-        } else {
-            dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
         }
 
         where:
@@ -1167,12 +1165,10 @@ class AlignAndSubstituteRulesSpec extends IntegrationTestKitSpec {
         dependencyInsightContains(result.output, "test.nebula:a", resultingVersion)
         dependencyInsightContains(result.output, "test.nebula:b", resultingVersion)
 
-        if (coreAlignment) {
-            dependencyInsightContains(result.output, "test.nebula:c", '0.5.0')
+        dependencyInsightContains(result.output, "test.nebula:c", resultingVersion) // alignment wins over the details.useVersion
 
+        if (coreAlignment) {
             assert result.output.contains("belongs to platform aligned-platform:rules-0-for-test.nebula-or-test.nebula.ext:$resultingVersion")
-        } else {
-            dependencyInsightContains(result.output, "test.nebula:c", resultingVersion)
         }
 
         where:

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAndSubstituteRulesWithSpringBoot1xPluginSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAndSubstituteRulesWithSpringBoot1xPluginSpec.groovy
@@ -58,12 +58,9 @@ class AlignAndSubstituteRulesWithSpringBoot1xPluginSpec extends AbstractRulesWit
         dependencyInsightContains(output, 'org.springframework:spring-aop', managedSpringVersion)
         dependencyInsightContains(output, 'org.springframework:spring-beans', managedSpringVersion)
         dependencyInsightContains(output, 'org.springframework:spring-expression', managedSpringVersion)
-
-        if (coreAlignment) {
-            dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
-        } else {
-            dependencyInsightContains(output, 'org.springframework:spring-core', managedSpringVersion)
-        }
+        dependencyInsightContains(output, 'org.springframework:spring-core', managedSpringVersion)
+        output.findAll("org.springframework.*:${managedSpringVersion}\n").size() >= 1
+        output.findAll("org.springframework.*:${extSpringVersion}\n").size() == 0
 
         where:
         extSpringVersion = '4.2.4.RELEASE'
@@ -88,19 +85,12 @@ class AlignAndSubstituteRulesWithSpringBoot1xPluginSpec extends AbstractRulesWit
 
         then:
         writeOutputToProjectDir(output)
-        if (coreAlignment) {
-            dependencyInsightContains(output, 'org.springframework:spring-aop', managedSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-beans', managedSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-expression', managedSpringVersion)
-
-            dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
-
-        } else {
-            dependencyInsightContains(output, 'org.springframework:spring-aop', extSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-beans', extSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-expression', extSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
-        }
+        dependencyInsightContains(output, 'org.springframework:spring-aop', extSpringVersion)
+        dependencyInsightContains(output, 'org.springframework:spring-beans', extSpringVersion)
+        dependencyInsightContains(output, 'org.springframework:spring-expression', extSpringVersion)
+        dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
+        output.findAll("org.springframework.*:${extSpringVersion}\n").size() >= 1
+        output.findAll("org.springframework.*:${managedSpringVersion}\n").size() == 0
 
         where:
         extSpringVersion = '5.1.8.RELEASE'
@@ -345,8 +335,8 @@ class AlignAndSubstituteRulesWithSpringBoot1xPluginSpec extends AbstractRulesWit
         then:
         writeOutputToProjectDir(output)
         if (coreAlignment) {
-            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', managedSlf4jVersion)
-            dependencyInsightContains(output, 'org.slf4j:slf4j-api', managedSlf4jVersion)
+            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', 'FAILED')
+            assert output.contains('Multiple forces on different versions for virtual platform aligned-platform')
         } else {
             dependencyInsightContains(output, 'org.slf4j:slf4j-simple', forcedVersion)
             dependencyInsightContains(output, 'org.slf4j:slf4j-api', forcedVersion)
@@ -419,8 +409,8 @@ class AlignAndSubstituteRulesWithSpringBoot1xPluginSpec extends AbstractRulesWit
         then:
         writeOutputToProjectDir(output)
         if (coreAlignment) {
-            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', managedSlf4jVersion)
-            dependencyInsightContains(output, 'org.slf4j:slf4j-api', managedSlf4jVersion)
+            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', 'FAILED')
+            assert output.contains('Multiple forces on different versions for virtual platform aligned-platform')
         } else {
             dependencyInsightContains(output, 'org.slf4j:slf4j-simple', forcedVersion)
             dependencyInsightContains(output, 'org.slf4j:slf4j-api', forcedVersion)

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAndSubstituteRulesWithSpringBoot2xPluginAndManagedDepsSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAndSubstituteRulesWithSpringBoot2xPluginAndManagedDepsSpec.groovy
@@ -61,12 +61,9 @@ class AlignAndSubstituteRulesWithSpringBoot2xPluginAndManagedDepsSpec extends Ab
         dependencyInsightContains(output, 'org.springframework:spring-aop', managedSpringVersion)
         dependencyInsightContains(output, 'org.springframework:spring-beans', managedSpringVersion)
         dependencyInsightContains(output, 'org.springframework:spring-expression', managedSpringVersion)
-
-        if (coreAlignment) {
-            dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
-        } else {
-            dependencyInsightContains(output, 'org.springframework:spring-core', managedSpringVersion)
-        }
+        dependencyInsightContains(output, 'org.springframework:spring-core', managedSpringVersion)
+        output.findAll("org.springframework.*:${managedSpringVersion}\n").size() >= 1
+        output.findAll("org.springframework.*:${extSpringVersion}\n").size() == 0
 
         where:
         extSpringVersion = '4.2.4.RELEASE'
@@ -93,19 +90,12 @@ class AlignAndSubstituteRulesWithSpringBoot2xPluginAndManagedDepsSpec extends Ab
 
         then:
         writeOutputToProjectDir(output)
-        if (coreAlignment) {
-            dependencyInsightContains(output, 'org.springframework:spring-aop', managedSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-beans', managedSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-expression', managedSpringVersion)
-
-            dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
-            
-        } else {
-            dependencyInsightContains(output, 'org.springframework:spring-aop', extSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-beans', extSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-expression', extSpringVersion)
-            dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
-        }
+        dependencyInsightContains(output, 'org.springframework:spring-aop', extSpringVersion)
+        dependencyInsightContains(output, 'org.springframework:spring-beans', extSpringVersion)
+        dependencyInsightContains(output, 'org.springframework:spring-expression', extSpringVersion)
+        dependencyInsightContains(output, 'org.springframework:spring-core', extSpringVersion)
+        output.findAll("org.springframework.*:${extSpringVersion}\n").size() >= 1
+        output.findAll("org.springframework.*:${managedSpringVersion}\n").size() == 0
 
         where:
         extSpringVersion = '5.1.8.RELEASE'
@@ -360,8 +350,8 @@ class AlignAndSubstituteRulesWithSpringBoot2xPluginAndManagedDepsSpec extends Ab
         then:
         writeOutputToProjectDir(output)
         if (coreAlignment) {
-            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', managedSlf4jVersion)
-            dependencyInsightContains(output, 'org.slf4j:slf4j-api', managedSlf4jVersion)
+            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', 'FAILED')
+            assert output.contains('Multiple forces on different versions for virtual platform aligned-platform')
         } else {
             dependencyInsightContains(output, 'org.slf4j:slf4j-simple', forcedVersion)
             dependencyInsightContains(output, 'org.slf4j:slf4j-api', forcedVersion)
@@ -436,8 +426,8 @@ class AlignAndSubstituteRulesWithSpringBoot2xPluginAndManagedDepsSpec extends Ab
         then:
         writeOutputToProjectDir(output)
         if (coreAlignment) {
-            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', managedSlf4jVersion)
-            dependencyInsightContains(output, 'org.slf4j:slf4j-api', managedSlf4jVersion)
+            dependencyInsightContains(output, 'org.slf4j:slf4j-simple', 'FAILED')
+            assert output.contains('Multiple forces on different versions for virtual platform aligned-platform')
         } else {
             dependencyInsightContains(output, 'org.slf4j:slf4j-simple', forcedVersion)
             dependencyInsightContains(output, 'org.slf4j:slf4j-api', forcedVersion)


### PR DESCRIPTION
Overall, the alignment changes result in more aligned dependencies, even though alignment now can be the primary contributor to a resolved version over setting a single module's `details.useVersion` (when it is in an aligned group)

The changes in 6.7-rc-1 and alignment are related to:
- That `substitutions are not applied to a virtual platform`
- https://github.com/gradle/gradle/issues/14172
- https://github.com/gradle/gradle/pull/14173