### PR TITLE
Switch to build service for sharing resolved rules between projects

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignRulesMultiprojectSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignRulesMultiprojectSpec.groovy
@@ -34,7 +34,7 @@ class AlignRulesMultiprojectSpec extends IntegrationSpec {
         fork = false
         rulesJsonFile = new File(projectDir, "${moduleName}.json")
         buildFile << """\
-            subprojects {
+            allprojects {
                 ${applyPlugin(ResolutionRulesPlugin)}
                 
 

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
@@ -564,4 +564,20 @@ class ResolutionRulesPluginSpec extends IntegrationSpec {
         then:
         !result.standardOutput.contains("Dependency resolution rules will not be applied to configuration ':nebulaRecommenderBom', it was resolved before the project was executed")
     }
+
+    def 'do not reject dependency if version is not part of the selector in rule'() {
+        given:
+        buildFile << """
+                     dependencies {
+                        implementation 'com.google.guava:guava:19.0'
+                     }
+                     """.stripIndent()
+
+        when:
+        def result = runTasks('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        !result.standardError.contains("esolution rules could not resolve all dependencies to align configuration ':compileClasspath':\n" +
+                " - com.google.guava:guava:19.0 -> com.google.guava:guava:19.0 - Could not find com.google.guava:guava:19.0")
+    }
 }

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
@@ -197,6 +197,20 @@ class ResolutionRulesPluginSpec extends IntegrationSpec {
         output.contains 'nebula.resolution-rules is using ruleset: rules.jar'
     }
 
+    def 'dependencies task with configuration on demand'() {
+        def subproject = addSubproject("subprojectA")
+        new File(subproject, "build.gradle") << """
+            apply plugin: 'java'
+            apply plugin: 'nebula.resolution-rules'
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(':subprojectA:dependencies', '--configuration', 'compileClasspath', '-Dorg.gradle.configureondemand=true')
+
+        then:
+        result.standardOutput.contains("Configuration on demand is an incubating feature.")
+    }
+
     def 'replace module'() {
         given:
         buildFile << """

--- a/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
@@ -577,7 +577,7 @@ class ResolutionRulesPluginSpec extends IntegrationSpec {
         def result = runTasks('dependencies', '--configuration', 'compileClasspath')
 
         then:
-        !result.standardError.contains("esolution rules could not resolve all dependencies to align configuration ':compileClasspath':\n" +
+        !result.standardError.contains("Resolution rules could not resolve all dependencies to align configuration ':compileClasspath':\n" +
                 " - com.google.guava:guava:19.0 -> com.google.guava:guava:19.0 - Could not find com.google.guava:guava:19.0")
     }
 }

--- a/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/plugin.kt
@@ -26,8 +26,12 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import java.io.File
-import java.util.*
+import java.io.Serializable
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import javax.inject.Inject
@@ -35,8 +39,6 @@ import javax.inject.Inject
 const val RESOLUTION_RULES_CONFIG_NAME = "resolutionRules"
 
 class ResolutionRulesPlugin : Plugin<Project> {
-    private val logger: Logger = Logging.getLogger(ResolutionRulesPlugin::class.java)
-    private val NEBULA_RECOMMENDER_BOM_CONFIG_NAME: String = "nebulaRecommenderBom"
     private lateinit var project: Project
     private lateinit var configurations: ConfigurationContainer
     private lateinit var extension: NebulaResolutionRulesExtension
@@ -44,7 +46,10 @@ class ResolutionRulesPlugin : Plugin<Project> {
             NEBULA_RECOMMENDER_BOM_CONFIG_NAME, SCALA_INCREMENTAL_ANALYSIS_CONFIGURATION_PREFIX, KTLINT_CONFIGURATION_PREFIX, REPOSITORY_CONTENT_DESCRIPTOR_CONFIGURATION_PREFIX)
     private val ignoredConfigurationSuffixes = listOf(PMD_CONFIGURATION_SUFFIX)
 
-    companion object Constants {
+    companion object {
+        val Logger: Logger = Logging.getLogger(ResolutionRulesPlugin::class.java)
+
+        const val NEBULA_RECOMMENDER_BOM_CONFIG_NAME: String = "nebulaRecommenderBom"
         const val SPRING_VERSION_MANAGEMENT_CONFIG_NAME = "versionManagement"
         const val KTLINT_CONFIGURATION_PREFIX = "ktlint"
         const val PMD_CONFIGURATION_SUFFIX = "PmdAuxClasspath"
@@ -59,18 +64,32 @@ class ResolutionRulesPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         this.project = project
         configurations = project.configurations
-        extension = project.extensions.create("nebulaResolutionRules", NebulaResolutionRulesExtension::class.java, project)
+        extension =
+            project.extensions.create("nebulaResolutionRules", NebulaResolutionRulesExtension::class.java, project)
 
         project.onExecute {
             if (isCoreAlignmentEnabled()) {
-                logger.info("${project.name}: coreAlignmentSupport feature enabled")
+                Logger.info("${project.name}: coreAlignmentSupport feature enabled")
             }
         }
 
         val rootProject = project.rootProject
-        rootProject.configurations.maybeCreate(RESOLUTION_RULES_CONFIG_NAME)
+        val configuration = project.configurations.maybeCreate(RESOLUTION_RULES_CONFIG_NAME)
+        if (project != rootProject) {
+            configuration.isCanBeConsumed = false
+            val rootProjectDependency = project.dependencies.project(
+                mapOf("path" to rootProject.path, "configuration" to RESOLUTION_RULES_CONFIG_NAME)
+            )
+            configuration.withDependencies { dependencies ->
+                dependencies.add(rootProjectDependency)
+            }
+        }
         if (rootProject.extensions.findByType(NebulaResolutionRulesExtension::class.java) == null) {
-            rootProject.extensions.create("nebulaResolutionRules", NebulaResolutionRulesExtension::class.java, rootProject)
+            rootProject.extensions.create(
+                "nebulaResolutionRules",
+                NebulaResolutionRulesExtension::class.java,
+                rootProject
+            )
         }
 
         project.configurations.all { config ->
@@ -86,7 +105,9 @@ class ResolutionRulesPlugin : Plugin<Project> {
             project.onExecute {
                 val ruleSet = extension.ruleSet()
                 when {
-                    config.state != Configuration.State.UNRESOLVED || config.getObservedState() != Configuration.State.UNRESOLVED -> logger.warn("Dependency resolution rules will not be applied to $config, it was resolved before the project was executed")
+                    config.state != Configuration.State.UNRESOLVED || config.getObservedState() != Configuration.State.UNRESOLVED -> Logger.warn(
+                        "Dependency resolution rules will not be applied to $config, it was resolved before the project was executed"
+                    )
                     else -> {
                         ruleSet.dependencyRulesPartOne().forEach { rule ->
                             rule.apply(project, config, config.resolutionStrategy, extension)
@@ -102,7 +123,7 @@ class ResolutionRulesPlugin : Plugin<Project> {
 
             config.onResolve {
                 if (!dependencyRulesApplied) {
-                    logger.debug("Skipping resolve rules for $config - dependency rules have not been applied")
+                    Logger.debug("Skipping resolve rules for $config - dependency rules have not been applied")
                 } else {
                     val ruleSet = extension.ruleSet()
                     ruleSet.resolveRules(isCoreAlignmentEnabled()).forEach { rule ->
@@ -123,48 +144,91 @@ class ResolutionRulesPlugin : Plugin<Project> {
     }
 }
 
-open class NebulaResolutionRulesExtension @Inject constructor(private val project: Project) {
+@Suppress("UnstableApiUsage")
+abstract class NebulaResolutionRulesService : BuildService<NebulaResolutionRulesService.Params> {
     companion object {
-        private val logger: Logger = Logging.getLogger(ResolutionRulesPlugin::class.java)
-        private val mapper = objectMapper()
+        private val Logger: Logger = Logging.getLogger(NebulaResolutionRulesService::class.java)
+        private val Mapper = objectMapper()
+
+        fun registerService(project: Project): Provider<NebulaResolutionRulesService> {
+            return project.gradle.sharedServices.registerIfAbsent(
+                "nebulaResolutionRules",
+                NebulaResolutionRulesService::class.java
+            ) { spec ->
+                val resolutionRules = resolveResolutionRules(project)
+                spec.parameters.getResolutionRules().set(ResolutionRules(resolutionRules))
+            }
+        }
+
+        private fun resolveResolutionRules(project: Project): Map<String, RuleSet> {
+            val configuration = project.configurations.getByName(RESOLUTION_RULES_CONFIG_NAME)
+            val files = configuration.resolve()
+            val rules = LinkedHashMap<String, RuleSet>()
+            for (file in files) {
+                val filename = file.name
+                Logger.debug("nebula.resolution-rules uses: $filename")
+                if (filename.endsWith(ResolutionRulesPlugin.JSON_EXT)) {
+                    rules.putRules(Mapper.parseJsonFile(file))
+                } else if (filename.endsWith(ResolutionRulesPlugin.JAR_EXT) || filename.endsWith(ResolutionRulesPlugin.ZIP_EXT)) {
+                    Logger.info("nebula.resolution-rules is using ruleset: $filename")
+                    ZipFile(file).use { zip ->
+                        val entries = zip.entries()
+                        while (entries.hasMoreElements()) {
+                            val entry = entries.nextElement()
+                            if (entry.name.endsWith(ResolutionRulesPlugin.JSON_EXT)) {
+                                rules.putRules(Mapper.parseJsonStream(zip, entry))
+                            }
+                        }
+                    }
+                } else {
+                    Logger.debug("Unsupported rules file extension for $file")
+                }
+            }
+            return rules
+        }
+
+        private fun MutableMap<String, RuleSet>.putRules(ruleSet: RuleSet) {
+            if (put(ruleSet.name!!, ruleSet) != null) {
+                Logger.info("Found rules with the same name. Overriding existing ruleset ${ruleSet.name}")
+            }
+        }
+
+        private fun ruleSetName(filename: String) =
+            filename.substring(0, filename.lastIndexOf(ResolutionRulesPlugin.JSON_EXT))
+
+        private fun ObjectMapper.parseJsonFile(file: File): RuleSet {
+            val ruleSetName = ruleSetName(file.name)
+            Logger.debug("Using $ruleSetName (${file.name}) a dependency rules source")
+            return readValue<RuleSet>(file).withName(ruleSetName)
+        }
+
+        private fun ObjectMapper.parseJsonStream(zip: ZipFile, entry: ZipEntry): RuleSet {
+            val ruleSetName = ruleSetName(File(entry.name).name)
+            Logger.debug("Using $ruleSetName (${zip.name}) a dependency rules source")
+            return readValue<RuleSet>(zip.getInputStream(entry)).withName(ruleSetName)
+        }
     }
 
+    interface Params : BuildServiceParameters {
+        fun getResolutionRules(): Property<ResolutionRules>
+    }
+
+    class ResolutionRules(val byFile: Map<String, RuleSet>) : Serializable
+}
+
+open class NebulaResolutionRulesExtension @Inject constructor(private val project: Project) {
     var include = ArrayList<String>()
     var optional = ArrayList<String>()
     var exclude = ArrayList<String>()
     var useCoreGradleAlignment = false
 
-    private val rulesByFile by lazy {
-        check(project == project.rootProject) { "This should only be called on the root project extension" }
-        val configuration = project.configurations.getByName(RESOLUTION_RULES_CONFIG_NAME)
-        val files = project.copyConfiguration(configuration).resolve()
-        val rules = LinkedHashMap<String, RuleSet>()
-        for (file in files) {
-            val filename = file.name
-            logger.debug("nebula.resolution-rules uses: $filename")
-            if (filename.endsWith(ResolutionRulesPlugin.JSON_EXT)) {
-                rules.putRules(mapper.parseJsonFile(file))
-            } else if (filename.endsWith(ResolutionRulesPlugin.JAR_EXT) || filename.endsWith(ResolutionRulesPlugin.ZIP_EXT)) {
-                logger.info("nebula.resolution-rules is using ruleset: $filename")
-                ZipFile(file).use { zip ->
-                    val entries = zip.entries()
-                    while (entries.hasMoreElements()) {
-                        val entry = entries.nextElement()
-                        if (entry.name.endsWith(ResolutionRulesPlugin.JSON_EXT)) {
-                            rules.putRules(mapper.parseJsonStream(zip, entry))
-                        }
-                    }
-                }
-            } else {
-                logger.debug("Unsupported rules file extension for $file")
-            }
-        }
-        rules
-    }
-
     fun ruleSet(): RuleSet {
-        val extension = project.rootProject.extensions.getByType(NebulaResolutionRulesExtension::class.java)
-        return extension.rulesByFile.filterKeys { ruleSet ->
+        val service = NebulaResolutionRulesService.registerService(project).get()
+        @Suppress("UnstableApiUsage") val rulesByFile = service.parameters
+            .getResolutionRules()
+            .get()
+            .byFile
+        return rulesByFile.filterKeys { ruleSet ->
             when {
                 ruleSet.startsWith(ResolutionRulesPlugin.OPTIONAL_PREFIX) -> {
                     val ruleSetWithoutPrefix = ruleSet.substring(ResolutionRulesPlugin.OPTIONAL_PREFIX.length)
@@ -174,25 +238,5 @@ open class NebulaResolutionRulesExtension @Inject constructor(private val projec
                 else -> !exclude.contains(ruleSet)
             }
         }.values.flatten()
-    }
-
-    private fun MutableMap<String, RuleSet>.putRules(ruleSet: RuleSet) {
-        if (put(ruleSet.name!!, ruleSet) != null) {
-            logger.info("Found rules with the same name. Overriding existing ruleset ${ruleSet.name}")
-        }
-    }
-
-    private fun ruleSetName(filename: String) = filename.substring(0, filename.lastIndexOf(ResolutionRulesPlugin.JSON_EXT))
-
-    private fun ObjectMapper.parseJsonFile(file: File): RuleSet {
-        val ruleSetName = ruleSetName(file.name)
-        logger.debug("Using $ruleSetName (${file.name}) a dependency rules source")
-        return readValue<RuleSet>(file).withName(ruleSetName)
-    }
-
-    private fun ObjectMapper.parseJsonStream(zip: ZipFile, entry: ZipEntry): RuleSet {
-        val ruleSetName = ruleSetName(File(entry.name).name)
-        logger.debug("Using $ruleSetName (${zip.name}) a dependency rules source")
-        return readValue<RuleSet>(zip.getInputStream(entry)).withName(ruleSetName)
     }
 }

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -228,12 +228,6 @@ data class RejectRule(
     val moduleVersionId = module.toModuleVersionId()
     @Transient lateinit var versionSelector: VersionSelector
 
-    init {
-        if (moduleVersionId.version.isNotEmpty()) {
-            versionSelector = VersionWithSelector(moduleVersionId.version).asSelector()
-        }
-    }
-
     override fun apply(
         project: Project,
         configuration: Configuration,
@@ -259,6 +253,7 @@ data class RejectRules(val rules: List<RejectRule>) : Rule {
             val candidate = selection.candidate
             val rules = ruleByModuleIdentifier[candidate.moduleIdentifier] ?: return@all
             rules.forEach { rule ->
+                rule.versionSelector = VersionWithSelector(rule.moduleVersionId.version).asSelector()
                 if (!rule.hasVersionSelector() || rule.versionSelector.accept(candidate.version)) {
                     val message = "rejected by rule ${rule.ruleSet} because '${rule.reason}'"
                     selection.reject(message)


### PR DESCRIPTION
This uses the same slightly hacky technique of allowing the first project that registers a build service to set a parameter to allow the first project configured to do the heavy lifting.

This has the disadvantage of exposing a `resolutionRules` configuration on each project and will mean the configuration is locked in every subproject again, but I don't see an another way to make this a singleton that's safe for parallelism.

The addition of `Serializable` all over the place is because build service parameters are subject to isolation.

My recollection is last time I tried to lock and resolve the `resolutionRules` configuration directly we ran into exceptions when the configuration needed to be modified after the fact, but I can't see why that would be the case.

I'll also follow this up with removal of our alignment implementation making core alignment the default, and make this a major release.