### PR TITLE
Fixed > remove enforcedPlatform from dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.9.10.+")
+    implementation platform("com.fasterxml.jackson:jackson-bom:2.9.10.+")
 
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7' // Not a direct dependency but ensures alignment when we upgrade Kotlin


### PR DESCRIPTION
enforcedPlatform for jackson-bom crashed builds when gradle-resolution-rules-plugin was applied in Gradle Wrapper and Gradle version was higher than 8.0