### PR TITLE
Parse rules JSON in parallel

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/ResolutionRulesPluginSpec.groovy
@@ -169,10 +169,9 @@ class ResolutionRulesPluginSpec extends AbstractIntegrationTestKitSpec {
 
         then:
         def output = result.output
-        output.contains 'Using duplicate-rules-sources (duplicate-rules-sources.json) a dependency rules source'
         output.contains 'Found rules with the same name. Overriding existing ruleset duplicate-rules-sources'
-        output.contains "Using duplicate-rules-sources ($projectDir/rules.jar) a dependency rules source"
-        output.contains "Using duplicate-rules-sources ($projectDir/rules.zip) a dependency rules source"
+        output.contains "Using duplicate-rules-sources ($projectDir/rules.zip!duplicate-rules-sources.json) a dependency rules source"
+        output.contains "Using duplicate-rules-sources ($projectDir/rules.jar!duplicate-rules-sources.json) a dependency rules source"
     }
 
      def 'output ruleset that is being used'() {

--- a/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
+++ b/src/main/kotlin/nebula/plugin/resolutionrules/rules.kt
@@ -26,8 +26,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutions
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector
-import org.gradle.api.logging.Logger
-import org.gradle.api.logging.Logging
 import java.io.Serializable
 
 interface Rule : Serializable {
@@ -51,7 +49,6 @@ interface ModuleRule : BasicRule {
 }
 
 data class RuleSet(
-    var name: String?,
     val replace: List<ReplaceRule> = emptyList(),
     val substitute: List<SubstituteRule> = emptyList(),
     val reject: List<RejectRule> = emptyList(),
@@ -59,6 +56,8 @@ data class RuleSet(
     val exclude: List<ExcludeRule> = emptyList(),
     val align: List<AlignRule> = emptyList()
 ) : Serializable {
+
+    lateinit var name: String
 
     fun dependencyRulesPartOne() =
         listOf(replace, deny, exclude).flatten() + listOf(SubstituteRules(substitute), RejectRules(reject))
@@ -86,7 +85,6 @@ fun RuleSet.withName(ruleSetName: String): RuleSet {
 }
 
 fun Collection<RuleSet>.flatten() = RuleSet(
-    "flattened",
     flatMap { it.replace },
     flatMap { it.substitute },
     flatMap { it.reject },


### PR DESCRIPTION
For all of the previous work we've done to avoid the overhead of parsing, this is still the #1 outlier for project configuration time in our projects. This uses streams, parallelising at the parsing stage so we can make this as quick as possible.